### PR TITLE
Add severity_threshold parameter for clair_scanner orb 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,9 @@ jobs:
         description: The path to the orb
     docker:
     - image: 361339499037.dkr.ecr.eu-west-1.amazonaws.com/pe-orbs:latest
+      aws_auth:
+        aws_access_key_id: $AWS_ACCESS_KEY_ID
+        aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
     steps:
     - checkout
     - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,6 @@ jobs:
         description: The path to the orb
     docker:
     - image: 361339499037.dkr.ecr.eu-west-1.amazonaws.com/pe-orbs:latest
-      aws_auth:
-        aws_access_key_id: $AWS_ACCESS_KEY_ID
-        aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
     steps:
     - checkout
     - setup_remote_docker:

--- a/clair-scanner/README.md
+++ b/clair-scanner/README.md
@@ -68,6 +68,7 @@ Parameters:
 - image: Name of the image to scan.
 - image_file: Path to a file containing images to scan.
 - whitelist: Path to a CVE whitelist
+- severity_threshold: The threshold above which discovered vulnerabilities will fail the build. May be 'Defcon1', 'Critical', 'High', 'Medium', 'Low', 'Negligible' or 'Unknown'. The Default is 'High'.
 
 ## Examples
 

--- a/clair-scanner/orb.yml
+++ b/clair-scanner/orb.yml
@@ -23,6 +23,10 @@ commands:
         type: "string"
         description: "Path to a CVE whitelist"
         default: ""
+      severity_threshold:
+        type: "string"
+        description: "The threshold above which discovered vulnerabilities will fail the build. May be 'Defcon1', 'Critical', 'High', 'Medium', 'Low', 'Negligible' or 'Unknown'"
+        default: "High"
     steps:
       - checkout
       - setup_remote_docker:

--- a/clair-scanner/scan.sh
+++ b/clair-scanner/scan.sh
@@ -25,9 +25,9 @@ if [ -n "<< parameters.image_file >>" ]; then
     images=$(cat "<< parameters.image_file >>")
     for image in $images; do
         docker pull "$image"
-        docker exec -it $CLAIR_SCANNER clair-scanner --ip ${scanner_ip} --clair=http://${clair_ip}:6060 -t High $WHITELIST "$image"
+        docker exec -it $CLAIR_SCANNER clair-scanner --ip ${scanner_ip} --clair=http://${clair_ip}:6060 -t "<< parameters.severity_threshold >>" $WHITELIST "$image"
     done
 else
     docker pull "<< parameters.image >>"
-    docker exec -it $CLAIR_SCANNER clair-scanner --ip ${scanner_ip} --clair=http://${clair_ip}:6060 -t High $WHITELIST "<< parameters.image >>"
+    docker exec -it $CLAIR_SCANNER clair-scanner --ip ${scanner_ip} --clair=http://${clair_ip}:6060 -t "<< parameters.severity_threshold >>" $WHITELIST "<< parameters.image >>"
 fi


### PR DESCRIPTION
This adds a severity_threshold parameter which sets the threshold above which discovered vulnerabilities will fail the build.