### PR TITLE
Add parameter for controlling the exit code

### DIFF
--- a/clair-scanner/README.md
+++ b/clair-scanner/README.md
@@ -68,7 +68,8 @@ Parameters:
 - image: Name of the image to scan.
 - image_file: Path to a file containing images to scan.
 - whitelist: Path to a CVE whitelist
-- severity_threshold: The threshold above which discovered vulnerabilities will fail the build. May be 'Defcon1', 'Critical', 'High', 'Medium', 'Low', 'Negligible' or 'Unknown'. The Default is 'High'.
+- severity_threshold: The threshold (equal and above) at which discovered vulnerabilities are reported. May be 'Defcon1', 'Critical', 'High', 'Medium', 'Low', 'Negligible' or 'Unknown'. The Default is 'High'.
+- fail_on_discovered_vulnerabilities: Fail command when vulnerabilities at severity equal to or above the threshold are discovered. Default is true.
 
 ## Examples
 

--- a/clair-scanner/orb.yml
+++ b/clair-scanner/orb.yml
@@ -30,7 +30,7 @@ commands:
       fail_on_discovered_vulnerabilities:
         type: "boolean"
         description: "Fail command when vulnerabilities at severity equal to or above the threshold are discovered"
-        default: "true"
+        default: true
     steps:
       - checkout
       - setup_remote_docker:

--- a/clair-scanner/orb.yml
+++ b/clair-scanner/orb.yml
@@ -25,8 +25,12 @@ commands:
         default: ""
       severity_threshold:
         type: "string"
-        description: "The threshold above which discovered vulnerabilities will fail the build. May be 'Defcon1', 'Critical', 'High', 'Medium', 'Low', 'Negligible' or 'Unknown'"
+        description: "The threshold (equal and above) at which discovered vulnerabilities are reported. May be 'Defcon1', 'Critical', 'High', 'Medium', 'Low', 'Negligible' or 'Unknown'"
         default: "High"
+      fail_on_discovered_vulnerabilities:
+        type: "boolean"
+        description: "Fail command when vulnerabilities at severity equal to or above the threshold are discovered"
+        default: "true"
     steps:
       - checkout
       - setup_remote_docker:

--- a/clair-scanner/scan.sh
+++ b/clair-scanner/scan.sh
@@ -48,7 +48,7 @@ else
     scan "<< parameters.image >>"
 fi
 
-if [ "<< fail_on_discovered_vulnerabilities >>" = "false"]
+if [ "<< parameters.fail_on_discovered_vulnerabilities >>" == "false" ]; then
     exit 0
 else
     exit $EXIT_STATUS

--- a/clair-scanner/scan.sh
+++ b/clair-scanner/scan.sh
@@ -48,4 +48,8 @@ else
     scan "<< parameters.image >>"
 fi
 
-exit $EXIT_STATUS
+if [ "<< fail_on_discovered_vulnerabilities >>" = "false"]
+    exit 0
+else
+    exit $EXIT_STATUS
+fi


### PR DESCRIPTION
We're running clair-scanning on a set of images and want to do some post-processing (i.e. parsing and communicating the results). So it would be helpful if failing the job is optional. 