### PR TITLE
Move clair reports into workspace directory

### DIFF
--- a/clair-scanner/orb.yml
+++ b/clair-scanner/orb.yml
@@ -40,4 +40,4 @@ commands:
           command: |
             include scan.sh
       - store_artifacts:
-          path: /clair-reports
+          path: clair-reports

--- a/clair-scanner/scan.sh
+++ b/clair-scanner/scan.sh
@@ -48,6 +48,8 @@ else
     scan "<< parameters.image >>"
 fi
 
+mv $REPORT_DIR .
+
 if [ "<< parameters.fail_on_discovered_vulnerabilities >>" == "false" ]; then
     exit 0
 else


### PR DESCRIPTION
Persisting to workspace does not work out of the box without a mv / cp command; error message says that path must be relative to workspace. So move it to workspace and rather store artifacts from there.
