### PR TITLE
Add better error messages

### DIFF
--- a/terraform/orb.yml
+++ b/terraform/orb.yml
@@ -45,6 +45,7 @@ commands:
     steps:
       - run:
           name: "terraform plan << parameters.path >> << parameters.label >>"
+          shell: /bin/bash -eo pipefail
           command: |
             include plan.sh
 
@@ -93,6 +94,7 @@ commands:
     steps:
       - run:
           name: "terraform apply << parameters.path >> << parameters.label >>"
+          shell: /bin/bash -eo pipefail
           command: |
             include apply.sh
 
@@ -133,6 +135,7 @@ commands:
     steps:
       - run:
           name: "terraform check << parameters.path >> << parameters.label >>"
+          shell: /bin/bash -eo pipefail
           command: |
             include check.sh
 
@@ -173,6 +176,7 @@ commands:
     steps:
       - run:
           name: "terraform destroy << parameters.path >> << parameters.label >>"
+          shell: /bin/bash -eo pipefail
           command: |
             include destroy.sh
 
@@ -213,6 +217,7 @@ commands:
     steps:
       - run:
           name: "terraform workspace new"
+          shell: /bin/bash -eo pipefail
           command: |
             include init.sh
             if [[ -z "$(terraform workspace list $module_path | grep $workspace)" ]]; then
@@ -267,6 +272,7 @@ commands:
           var_file: << parameters.var_file >>
       - run:
           name: "terraform workspace delete"
+          shell: /bin/bash -eo pipefail
           command: |
             include init.sh
             exec terraform workspace delete "$workspace" "$module_path"

--- a/terraform/put_plan.py
+++ b/terraform/put_plan.py
@@ -82,7 +82,9 @@ if __name__ == '__main__':
     env = os.environ.get('TF_ENV_LABEL', '')
 
     if not pr:
-        print(f'This build is not for a Pull Request - not adding a comment')
+        print(
+            f'This build is not for a Pull Request - A comment will NOT be added if a PR is later opened for this branch.'
+        )
         exit()
 
     label = create_label(module_path, workspace, env, init_args, plan_args)

--- a/terraform/put_plan.py
+++ b/terraform/put_plan.py
@@ -81,5 +81,9 @@ if __name__ == '__main__':
     pr = os.environ['CIRCLE_PR_NUMBER']
     env = os.environ.get('TF_ENV_LABEL', '')
 
+    if not pr:
+        print(f'This build is not for a Pull Request - not adding a comment')
+        exit()
+
     label = create_label(module_path, workspace, env, init_args, plan_args)
     put(owner, repo, int(pr), label)


### PR DESCRIPTION
Prevent CircleCI from running the orb if bash isn't in the image.
Don't fail if a build is for a branch with no PR.