### PR TITLE
Mask secrets

### DIFF
--- a/terraform/apply.sh
+++ b/terraform/apply.sh
@@ -20,6 +20,7 @@ if [[ "<< parameters.auto_approve >>" == "true" && -n "<< parameters.target >>" 
 fi
 
 terraform plan -input=false -no-color -detailed-exitcode -out=plan.out $PLAN_ARGS "$module_path" \
+    | $TFMASK \
     | sed '1,/---/d' \
         >plan.txt
 
@@ -39,7 +40,7 @@ elif [[ $TF_EXIT -eq 2 ]]; then
 
     if [ "<< parameters.auto_approve >>" = "true" ]; then
         echo "Automatically approving plan"
-        exec terraform apply -input=false -no-color -auto-approve plan.out
+        exec terraform apply -input=false -no-color -auto-approve plan.out | $TFMASK
     fi
 
     export TF_ENV_LABEL="<< parameters.label >>"
@@ -51,7 +52,7 @@ elif [[ $TF_EXIT -eq 2 ]]; then
 
     if python3 /tmp/cmp.py plan.txt approved-plan.txt; then
         echo "Applying approved plan"
-        exec terraform apply -input=false -no-color -auto-approve plan.out
+        exec terraform apply -input=false -no-color -auto-approve plan.out | $TFMASK
     else
         echo "Plan has changed - approval needed"
         cat plan.txt

--- a/terraform/check.sh
+++ b/terraform/check.sh
@@ -6,6 +6,7 @@ terraform workspace select "$workspace" "$module_path"
 set +e
 
 terraform plan -input=false -no-color -detailed-exitcode $PLAN_ARGS "$module_path" \
+    | $TFMASK \
     | sed '1,/---/d' \
         >plan.txt
 

--- a/terraform/executor/Dockerfile
+++ b/terraform/executor/Dockerfile
@@ -1,3 +1,8 @@
+FROM golang:1.12.6 AS tfmask
+
+RUN git clone https://github.com/cloudposse/tfmask.git
+RUN cd tfmask && make && make go/build
+
 FROM debian:buster-slim
 
 # This is the default executor image in the terraform orb
@@ -66,5 +71,8 @@ RUN pip3 install awscli
 
 RUN mkdir -p /usr/local/share/terraform/plugin-cache
 ENV TF_PLUGIN_CACHE_DIR=/usr/local/share/terraform/plugin-cache
+
+COPY --from=tfmask /go/tfmask/release/tfmask /usr/local/bin/tfmask
+ENV TFMASK_RESOURCES_REGEX="(?i)^(random_id|kubernetes_secret|acme_certificate).*$"
 
 ENTRYPOINT ["/usr/local/bin/terraform"]

--- a/terraform/init.sh
+++ b/terraform/init.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+TFMASK=tfmask
+if ! hash $TFMASK 2>/dev/null; then
+    TFMASK=cat
+fi
+
 GCLOUD_SERVICE_KEY="${GCLOUD_SERVICE_KEY:-$GOOGLE_SERVICE_ACCOUNT}"
 
 if [ -n "$GCLOUD_SERVICE_KEY" ]; then

--- a/terraform/plan.sh
+++ b/terraform/plan.sh
@@ -12,6 +12,7 @@ set +e
 exec 3>&1
 
 terraform plan -input=false -no-color -detailed-exitcode -out=plan.out $PLAN_ARGS "$module_path" \
+    | $TFMASK \
     | tee /dev/fd/3 \
     | sed '1,/---/d' \
         >plan.txt


### PR DESCRIPTION
Add tfmask to the default executor, and use it to mask output from plan and apply.

The default resource mask pattern is extended to include kubernetes_secret and acme_certificate resources.