### PR TITLE
Add Aiven's terraform provider

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -278,6 +278,43 @@ workflows:
 
 ```
 
+### Using the aiven provider
+
+When using the default or terraform-0_11 executors, OVO's 
+`terraform-provider-aiven` is available at version `0.0.1`.
+To use Aiven's `terraform-provider-aiven` set the AIVEN_PROVIDER 
+environment variable and set a version equal or greater than `1.0.0` in 
+the provider configuration.
+
+When using the terraform-0_12 executor Aiven's `terraform-provider-aiven` is
+always available. (And OVO's is not).
+
+```yaml
+
+version: 2.1
+
+orbs:
+  terraform: ovotech/terraform@1
+  
+jobs:
+  terraform_plan:
+    executor: terraform/default
+    environment:
+      AIVEN_PROVIDER: true
+    steps:
+      - checkout
+      - terraform/plan:
+          path: tf
+
+workflows:
+  test:
+    jobs:
+      - terraform_plan:
+          filters:
+            branches:
+              ignore: master
+```
+
 ### Checking for changes
 
 This examples checks the infrastructure every morning. If changes are

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -17,17 +17,21 @@ The executor named `default` is the same as `terraform-0_11`
 This executor uses terraform 0.11
 
 It also contains:
-- ovo's terraform-provider-aiven
+- ovo's terraform-provider-aiven as version 0.0.1
 - helm + terraform-provider-helm
 - terraform-provider-acme
 - google-cloud-sdk
 - aws-cli
+
+If the AIVEN_PROVIDER environment variable is set, also has:
+- Aiven's terraform-provider-aiven from versions 1.0.0+
 
 ### terraform-0_12
 
 This executor uses terraform 0.12
 
 It also contains:
+- Aiven's terraform-provider-aiven
 - google-cloud-sdk
 - helm
 - aws-cli

--- a/terraform/executor/Dockerfile-0.11
+++ b/terraform/executor/Dockerfile-0.11
@@ -12,6 +12,7 @@ ARG GCLOUD_VERSION=247.0.0
 ARG HELM_VERSION=2.14.1
 ARG TF_HELM_VERSIONS="0.6.0 0.5.1 0.5.0 0.4.0 0.3.2 0.3.1 0.3.0 0.2.0 0.1.0"
 ARG TF_ACME_VERSIONS="1.0.0 0.6.0 0.5.0 0.4.0 0.3.0"
+ARG TF_AIVEN_VERSIONS="1.0.0 1.0.1 1.0.2 1.0.3 1.0.4 1.0.5 1.0.6 1.0.7 1.0.8 1.0.9 1.0.10"
 
 ENV TF_IN_AUTOMATION=yep
 
@@ -38,8 +39,14 @@ RUN mkdir -p /root/.terraform.d/plugins \
  && curl -sL https://s3-eu-west-1.amazonaws.com/terraform-provider-aiven/master/terraform-provider-aiven_linux_amd64.zip \
       -o terraform-provider-aiven_linux_amd64.zip \
  && unzip terraform-provider-aiven_linux_amd64.zip \
- && mv terraform-provider-aiven /root/.terraform.d/plugins \
+ && mv terraform-provider-aiven /root/.terraform.d/plugins/terraform-provider-aiven_v0.0.1 \
  && rm -rf terraform*
+
+RUN mkdir -p /root/aiven \
+ && for TF_AIVEN_VERSION in $TF_AIVEN_VERSIONS; do \
+      curl -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven-linux_amd64" \
+        -o /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
+    done
 
 RUN curl -sL "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz" | tar -xzvf- \
  && mv linux-amd64/helm /usr/local/bin/helm \

--- a/terraform/executor/Dockerfile-0.12
+++ b/terraform/executor/Dockerfile-0.12
@@ -10,6 +10,7 @@ FROM debian:buster-slim
 ARG TF_VERSION=0.12.2
 ARG GCLOUD_VERSION=247.0.0
 ARG HELM_VERSION=2.14.1
+ARG TF_AIVEN_VERSIONS="1.0.0 1.0.1 1.0.2 1.0.3 1.0.4 1.0.5 1.0.6 1.0.7 1.0.8 1.0.9 1.0.10"
 
 ENV TF_IN_AUTOMATION=yep
 
@@ -31,6 +32,12 @@ RUN curl -sL https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${
  && unzip terraform.zip \
  && mv terraform /usr/local/bin \
  && rm -rf terraform*
+
+RUN mkdir -p /root/.terraform.d/plugins \
+ && for TF_AIVEN_VERSION in $TF_AIVEN_VERSIONS; do \
+      curl -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven-linux_amd64" \
+        -o /root/.terraform.d/plugins/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
+    done
 
 RUN curl -sL "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz" | tar -xzvf- \
  && mv linux-amd64/helm /usr/local/bin/helm \

--- a/terraform/init.sh
+++ b/terraform/init.sh
@@ -58,5 +58,10 @@ if [ -n "<< parameters.var_file >>" ]; then
     done
 fi
 
+echo "AIVEN_PROVIDER: $AIVEN_PROVIDER"
+if [ -n "$AIVEN_PROVIDER" ]; then
+    ln -fs /root/aiven/* /root/.terraform.d/plugins/
+fi
+
 rm -rf .terraform
 terraform init -input=false -no-color $INIT_ARGS "$module_path"

--- a/terraform/orb.yml
+++ b/terraform/orb.yml
@@ -285,6 +285,48 @@ commands:
             include init.sh
             terraform workspace delete "$workspace" "$module_path"
 
+  version:
+    description: "Prints terraform and provider versions"
+    parameters:
+      path:
+        type: "string"
+        description: "Path to the terraform module"
+      workspace:
+        type: "string"
+        description: "Name of the terraform workspace to create"
+        default: "default"
+      label:
+        type: "string"
+        description: "A friendly name for the environment this step is for"
+        default: ""
+      parallelism:
+        type: "string"
+        description: "Limit the number of concurrent operations"
+        default: ""
+      backend_config_file:
+        type: "string"
+        description: "Path to a backend config file"
+        default: ""
+      backend_config:
+        type: "string"
+        description: "Comma separated list of backend configs to set, e.g. 'foo=bar'"
+        default: ""
+      var:
+        type: "string"
+        description: "Comma separated list of vars to set, e.g. 'foo=bar'"
+        default: ""
+      var_file:
+        type: "string"
+        description: "Comma separated list of var file paths"
+        default: ""
+    steps:
+      - run:
+          name: "terraform version"
+          shell: /bin/bash -eo pipefail
+          command: |
+            include init.sh
+            terraform version
+
 jobs:
   plan:
     executor: default


### PR DESCRIPTION
Adds Aiven's terraform provider to the terraform executors.

When using the default or terraform-0_11 executors, OVO's 
`terraform-provider-aiven` is available at version `0.0.1`.
To use Aiven's `terraform-provider-aiven` set the AIVEN_PROVIDER 
environment variable and set a version equal or greater than `1.0.0` in 
the provider configuration.

 When using the terraform-0_12 executor Aiven's `terraform-provider-aiven` is
always available. (And OVO's is not).

This also adds a version command for testing, which may or may not be useful in the future. I've left it undocumented until I decide.