### PR TITLE
Handle exit code 5 for unsupported images

### DIFF
--- a/clair-scanner/orb.yml
+++ b/clair-scanner/orb.yml
@@ -31,12 +31,16 @@ commands:
         type: "boolean"
         description: "Fail command when vulnerabilities at severity equal to or above the threshold are discovered"
         default: true
+      fail_on_unsupported_images:
+        type: "boolean"
+        description: "Fail command when image cannot be scanned for vulnerabilities"
+        default: true
     steps:
       - checkout
       - setup_remote_docker:
           version: 17.11.0-ce
       - run:
-          name: "vulnerability scan"
+          name: "Vulnerability scan"
           command: |
             include scan.sh
       - store_artifacts:


### PR DESCRIPTION

 * Support for new status code 5, which is returned when image scanning cannot be performed. With an option to fail or not to fail if that is the case.
 * Support for unexpected status codes. 
 * Delete report after each image, if present
 * Less verbose, prints less to console. Results are present as artifacts, which is sufficient.

Note; I'm not very experienced in i bash scripts.