### PR TITLE
open files with utf-8 in python scripts

### DIFF
--- a/terraform/cmp.py
+++ b/terraform/cmp.py
@@ -1,7 +1,9 @@
+#!/usr/bin/env python3
+
 import sys
 
-with open(sys.argv[1]) as f:
+with open(sys.argv[1], encoding='utf-8') as f:
     first = f.read()
-with open(sys.argv[2]) as f:
+with open(sys.argv[2], encoding='utf-8') as f:
     second = f.read()
 exit(0 if first.strip() == second.strip() else 1)

--- a/tools/include.py
+++ b/tools/include.py
@@ -52,7 +52,7 @@ def read_file(path: str, pad: str = '') -> None:
 
     do_escape = not path.endswith('.yml')
 
-    with open(path) as f:
+    with open(path, encoding='utf-8') as f:
 
         #if path.endswith('.py'):
         #    for line in python_minifier.minify(f.read(), rename_locals=False, hoist_literals=False).splitlines():


### PR DESCRIPTION
In some environments (with odd locales) `open()` fails unless encoding is specified. Refer to https://github.com/RGF-team/rgf/issues/65, https://github.com/henry0312/pytest-codestyle/pull/34.

Please consider marking this PR with `orbtoberfest` label: https://hacktoberfest.circleci.com/#hacktoberfestOnCircleCI. Thanks a lot!