### PR TITLE
Add docker load func

### DIFF
--- a/clair-scanner/CHANGELOG.md
+++ b/clair-scanner/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+All notable changes to the orb will be documented in this file.
+Orbs are immutable, some orb versions with no significant changes are
+not listed.
+
+## ovotech/clair-scanner@1.6.0
+Start of the changelog

--- a/clair-scanner/README.md
+++ b/clair-scanner/README.md
@@ -66,6 +66,7 @@ build will fail. Vulnerabilities can be approved using a whitelist file.
 Parameters:
 
 - `disable_verbose_console_output`: Disable verbose Clair output. Default is false.
+- `docker_tar_dir`: Absolute path of directory of tarballs containing docker images to scan. Default is '/docker-tars'.
 - `fail_on_discovered_vulnerabilities`: Fail command when vulnerabilities at severity equal to or above the threshold are discovered. Default is true.
 - `fail_on_unsupported_images`: Fail command when image cannot be scanned for vulnerabilities. Default is true.
 - `image`: Name of the image to scan.

--- a/clair-scanner/orb.yml
+++ b/clair-scanner/orb.yml
@@ -42,7 +42,7 @@ commands:
       docker_tar_dir:
         type: "string"
         description: "Path of directory that Docker tarballs are stored"
-        default: "/docker-tar-dir"
+        default: "/docker-tars"
     steps:
       - checkout
       - setup_remote_docker:

--- a/clair-scanner/orb.yml
+++ b/clair-scanner/orb.yml
@@ -39,6 +39,10 @@ commands:
         type: "boolean"
         description: "Disable verbose console output"
         default: false
+      docker_tar_dir:
+        type: "string"
+        description: "Path of directory that Docker tarballs are stored"
+        default: "/docker-tar-dir"
     steps:
       - checkout
       - setup_remote_docker:

--- a/clair-scanner/orb_version.txt
+++ b/clair-scanner/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/clair-scanner@1.5.0
+ovotech/clair-scanner@1.6.0

--- a/clair-scanner/scan.sh
+++ b/clair-scanner/scan.sh
@@ -70,8 +70,8 @@ EXIT_STATUS=0
 
 for entry in "<< parameters.docker_tar_dir >>"/*.tar; do
     [ -e "$entry" ] || continue
-    images=$(docker load -i $entry | sed -e 's/Loaded image: //g')
-    for image in images; do
+    images=$(docker load -i "$entry" | sed -e 's/Loaded image: //g')
+    for image in $images; do
         scan "$image"
     done
 done

--- a/clair-scanner/scan.sh
+++ b/clair-scanner/scan.sh
@@ -2,8 +2,10 @@
 
 set -e
 
-if [ -z "<< parameters.image_file >><< parameters.image >>" ]; then
-    echo "Either the image_file or image parameters must be present"
+DOCKER_TAR_DIR="<< parameters.docker_tar_dir >>"
+
+if [ -z "<< parameters.image_file >><< parameters.image >>" ] && [ -z "$(ls -A "$DOCKER_TAR_DIR" 2>/dev/null)" ]; then
+    echo "image_file or image parameters or docker tarballs must be present"
     exit 255
 fi
 
@@ -68,7 +70,7 @@ function scan() {
 
 EXIT_STATUS=0
 
-for entry in "<< parameters.docker_tar_dir >>"/*.tar; do
+for entry in "$DOCKER_TAR_DIR"/*.tar; do
     [ -e "$entry" ] || continue
     images=$(docker load -i "$entry" | sed -e 's/Loaded image: //g')
     for image in $images; do

--- a/clair-scanner/scan.sh
+++ b/clair-scanner/scan.sh
@@ -84,7 +84,8 @@ if [ -n "<< parameters.image_file >>" ]; then
         docker pull "$image"
         scan "$image"
     done
-elif [ -n "<< parameters.image >>" ]; then
+fi
+if [ -n "<< parameters.image >>" ]; then
     image="<< parameters.image >>"
     docker pull "$image"
     scan "$image"

--- a/clair-scanner/scan.sh
+++ b/clair-scanner/scan.sh
@@ -84,7 +84,7 @@ if [ -n "<< parameters.image_file >>" ]; then
         docker pull "$image"
         scan "$image"
     done
-else
+elif [ -n "<< parameters.image >>" ]; then
     image="<< parameters.image >>"
     docker pull "$image"
     scan "$image"


### PR DESCRIPTION
fixes #48 

tested with the following:

```yaml
...
...
  save_images:
    executor: clair_scanner/default
    steps:
    - setup_remote_docker
    - run: |
        mkdir /docker-tars
        docker pull debian:buster
        docker save -o /docker-tars/debian.tar debian:buster
    - persist_to_workspace:
        root: /
        paths:
          - docker-tars
  scan_loaded_images:
    executor: clair_scanner/default
    steps:
    - attach_workspace:
        at: /tmp/workspace
    - clair_scanner/scan:
        docker_tar_dir: /tmp/workspace/docker-tars
  scan_no_images:
    executor: clair_scanner/default
    steps:
    - clair_scanner/scan

workflows:
  test:
    jobs:
      - save_images
      - scan_loaded_images:
          requires:
            - save_images
      - scan_no_images
```

`scan_loaded_images` scans debian:buster as expected.

`scan_no_images` fails as expected with:
```
image_file or image parameters or docker tarballs must be present
Exited with code 255
```