### PR TITLE
Add initial snyk support in rac-gcp-deploy

### DIFF
--- a/rac-gcp-deploy/executor/Dockerfile
+++ b/rac-gcp-deploy/executor/Dockerfile
@@ -38,6 +38,13 @@ RUN set -x \
   && apk del --purge .build-deps \
   && rm -rf /tmp/sbt-${SBT_VERSION}.tgz /var/cache/apk/*
 
+RUN apk add -q --no-progress --no-cache curl wget libstdc++ sudo \
+  && curl -s https://api.github.com/repos/snyk/snyk/releases/latest | grep "browser_download_url" | grep alpine | cut -d '"' -f 4 | xargs wget -q \
+  && sha256sum -c snyk-alpine.sha256 \
+  && sudo mv snyk-alpine /usr/local/bin/snyk \
+  && sudo chmod +x /usr/local/bin/snyk \
+  && snyk config set disableSuggestions=true
+
 # Install Docker
 
 # Docker.com returns the URL of the latest binary when you hit a directory listing

--- a/rac-gcp-deploy/orb.yml
+++ b/rac-gcp-deploy/orb.yml
@@ -70,6 +70,20 @@ commands:
           name: "Create Bintray credentials file"
           command: echo "credentials += Credentials(\"Bintray\", \"dl.bintray.com\", \"$<<parameters.username>>\", \"$<<parameters.api-key>>\")" > credentials.sbt
 
+  snyk_monitor:
+    description: "Runs snyk monitor"
+    parameters:
+      api-key:
+        description: "Name of the environment variable storing the snyk api key"
+        type: env_var_name
+    steps:
+      - run:
+          name: "Run snyk monitor"
+          command: |
+            echo 'addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")' > project/sbt-dependency-graph.sbt
+            snyk auth $<<parameters.api-key>>
+            snyk monitor --project-name="${CIRCLE_PROJECT_REPONAME}"
+
   initialize_gcloud:
     description: "Initialize the `gcloud` CLI"
     parameters:
@@ -332,6 +346,10 @@ jobs:
         description: "Name of environment variable storing the PRD Google project ID to connect with via the gcloud CLI"
         type: env_var_name
         default: PRD_PROJECT_ID
+      snyk-api-key:
+        description: "Name of the environment variable storing the snyk api key"
+        default: SNYK_TOKEN
+        type: env_var_name
     executor: <<parameters.executor>>
     steps:
       - setup_remote_docker
@@ -379,6 +397,8 @@ jobs:
             docker tag "${NONPROD_IMAGE_ROOT}:latest" "${PRD_IMAGE_ROOT}:latest"
             docker tag "${NONPROD_IMAGE_ROOT}:$(cat version.txt)" "${PRD_IMAGE_ROOT}:$(cat version.txt)"
             docker push "${PRD_IMAGE_ROOT}"
+      - snyk_monitor:
+          api-key: <<parameters.snyk-api-key>>
       - persist_workspace:
           to: <<parameters.workspace-dir>>
 
@@ -434,7 +454,6 @@ jobs:
             helm upgrade $<<parameters.helm-release-name>> ./helm/$CIRCLE_PROJECT_REPONAME -f ./helm/environments/nonprod.yaml --install --wait \
               --set "image.repository=${NONPROD_IMAGE_ROOT}" \
               --set "image.tag=$(cat version.txt)"
-
 
   prd-deploy:
     parameters:


### PR DESCRIPTION
Change to run `snyk monitor` at the end of the `release` step.

When merged, this will automatically enable Snyk to be run on the next release of our projects (since we depend on the latest `1.x` version of the orb in the projects).

Snyk has their own [orb](https://circleci.com/orbs/registry/orb/snyk/snyk), but since  CircleCI doesn't support using multiple orbs, we've extracted the necessary functionality from the Snyk orb to our own orb.

In order to keep things simple, I've opted to exclude some changes:
- run `snyk monitor` on deploy and have a separate snyk project per environment,
- run `snyk test` on pull requests and comment on the pull request with the output.

Still left to be done:
- [x] ~setup the `SNYK_TOKEN` environment variable in the `rac` context,~
  this is using a service account, and the key is stored in 1Password
- [x] ~cleanup existing projects in the Snyk organization,~
- [x] ~verify that the step is working as expected.~