### PR TITLE
Fixing Aiven provider download url

### DIFF
--- a/terraform/CHANGELOG.md
+++ b/terraform/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
 not listed.
 
+## ovotech/terraform@1.6.2
+### Fixed
+- Older versions of aiven-provider that were accidentally left out of 1.6.1 have been restored
+
 ## ovotech/terraform@1.6.1
 ### Changed
 - Updated executors to include:

--- a/terraform/executor/Dockerfile-0.11
+++ b/terraform/executor/Dockerfile-0.11
@@ -58,7 +58,7 @@ RUN mkdir -p /root/aiven \
       curl -f -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven-linux_amd64" \
         -o /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
       chmod +x /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
-    done
+    done \
  && for TF_AIVEN_VERSION in $TF_AIVEN_VERSIONS; do \
       curl -f -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven-linux_amd64_v${TF_AIVEN_VERSION}" \
         -o /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \

--- a/terraform/executor/Dockerfile-0.11
+++ b/terraform/executor/Dockerfile-0.11
@@ -60,7 +60,7 @@ RUN mkdir -p /root/aiven \
       chmod +x /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
     done \
  && for TF_AIVEN_VERSION in $TF_AIVEN_VERSIONS; do \
-      curl -f -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven-linux_amd64_v${TF_AIVEN_VERSION}" \
+      curl -f -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven-linux-amd64_v${TF_AIVEN_VERSION}" \
         -o /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
       chmod +x /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
     done

--- a/terraform/executor/Dockerfile-0.11
+++ b/terraform/executor/Dockerfile-0.11
@@ -12,7 +12,8 @@ ARG HELM_VERSION=2.16.1
 ARG TFSWITCH_VERSION=0.7.737
 ARG TF_HELM_VERSIONS="0.6.0 0.5.1 0.5.0 0.4.0 0.3.2 0.3.1 0.3.0 0.2.0 0.1.0"
 ARG TF_ACME_VERSIONS="1.0.0 0.6.0 0.5.0 0.4.0 0.3.0"
-ARG TF_AIVEN_VERSIONS="1.0.0 1.0.1 1.0.2 1.0.3 1.0.4 1.0.5 1.0.6 1.0.7 1.0.8 1.0.9 1.0.10 1.0.11 1.0.12 1.0.13 1.0.15 1.0.16 1.0.17 1.0.19"
+ARG TF_AIVEN_VERSIONS="1.0.19 1.0.20 1.1.0"
+ARG TF_OLD_AIVEN_VERSIONS="1.0.0 1.0.1 1.0.2 1.0.3 1.0.4 1.0.5 1.0.6 1.0.7 1.0.8 1.0.9 1.0.10 1.0.11 1.0.12 1.0.13 1.0.15 1.0.16 1.0.17 1.0.18"
 ARG TF_OVO_VERSIONS="1.0.0"
 
 # Terraform environment variables
@@ -36,7 +37,7 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
  && rm -rf /var/lib/apt/lists/*
 
-RUN curl -sL https://github.com/warrensbox/terraform-switcher/releases/download/${TFSWITCH_VERSION}/terraform-switcher_${TFSWITCH_VERSION}_linux_amd64.tar.gz -o tfswitch.tar.gz \
+RUN curl -fsL https://github.com/warrensbox/terraform-switcher/releases/download/${TFSWITCH_VERSION}/terraform-switcher_${TFSWITCH_VERSION}_linux_amd64.tar.gz -o tfswitch.tar.gz \
  && tar -xvf tfswitch.tar.gz \
  && mv tfswitch /usr/local/bin \
  && rm -rf tfswitch \
@@ -46,20 +47,25 @@ RUN curl -sL https://github.com/warrensbox/terraform-switcher/releases/download/
 RUN mkdir -p $TF_PLUGIN_CACHE_DIR
 
 RUN mkdir -p /root/.terraform.d/plugins \
- && curl -sL https://s3-eu-west-1.amazonaws.com/terraform-provider-aiven/master/terraform-provider-aiven_linux_amd64.zip \
+ && curl -fsL https://s3-eu-west-1.amazonaws.com/terraform-provider-aiven/master/terraform-provider-aiven_linux_amd64.zip \
       -o terraform-provider-aiven_linux_amd64.zip \
  && unzip terraform-provider-aiven_linux_amd64.zip \
  && mv terraform-provider-aiven_v0.0.1 /root/.terraform.d/plugins/terraform-provider-aiven_v0.0.1 \
  && rm -rf terraform*
 
 RUN mkdir -p /root/aiven \
+ && for TF_AIVEN_VERSION in $TF_OLD_AIVEN_VERSIONS; do \
+      curl -f -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven-linux_amd64" \
+        -o /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
+      chmod +x /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
+    done
  && for TF_AIVEN_VERSION in $TF_AIVEN_VERSIONS; do \
-      curl -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven-linux_amd64" \
+      curl -f -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven-linux_amd64_v${TF_AIVEN_VERSION}" \
         -o /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
       chmod +x /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
     done
 
-RUN curl -sL "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz" | tar -xzvf- \
+RUN curl -fsL "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz" | tar -xzvf- \
  && mv linux-amd64/helm /usr/local/bin/helm \
  && rm -rf helm*.tar.gz linux-amd64/ \
  && helm init --client-only
@@ -67,14 +73,14 @@ ENV HELM_HOME /root/.helm
 
 # This is extremely slow for some reason
 RUN for TF_HELM_VERSION in $TF_HELM_VERSIONS; do \
-      curl -L "https://github.com/terraform-providers/terraform-provider-helm/releases/download/v${TF_HELM_VERSION}/terraform-provider-helm_v${TF_HELM_VERSION}_linux_amd64.tar.gz" | tar -xzvf- \
+      curl -f -L "https://github.com/terraform-providers/terraform-provider-helm/releases/download/v${TF_HELM_VERSION}/terraform-provider-helm_v${TF_HELM_VERSION}_linux_amd64.tar.gz" | tar -xzvf- \
       && mv terraform-provider-helm_linux_amd64/terraform-provider-helm /root/.terraform.d/plugins/terraform-provider-helm_v${TF_HELM_VERSION} \
       && rm -rf terraform-provider-helm*; \
     done
 
 # acme provider
 RUN for TF_ACME_VERSION in $TF_ACME_VERSIONS; do \
-      curl -L https://github.com/vancluever/terraform-provider-acme/releases/download/v${TF_ACME_VERSION}/terraform-provider-acme_v${TF_ACME_VERSION}_linux_amd64.zip -o acme.zip \
+      curl -f -L https://github.com/vancluever/terraform-provider-acme/releases/download/v${TF_ACME_VERSION}/terraform-provider-acme_v${TF_ACME_VERSION}_linux_amd64.zip -o acme.zip \
       && unzip acme.zip -d /root/.terraform.d/plugins \
       && rm acme.zip \
       && mv /root/.terraform.d/plugins/terraform-provider-acme /root/.terraform.d/plugins/terraform-provider-acme_v${TF_ACME_VERSION}; \
@@ -82,12 +88,12 @@ RUN for TF_ACME_VERSION in $TF_ACME_VERSIONS; do \
 
 # ovo provider
 RUN for TF_OVO_VERSION in $TF_OVO_VERSIONS; do \
-      curl -L https://ovo-kafka-user.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
+      curl -f -L https://ovo-kafka-user.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
       && unzip ovo.zip -d /root/.terraform.d/plugins \
       && rm ovo.zip; \
     done
 
-RUN curl -sL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_VERSION}-linux-x86_64.tar.gz -o /opt/google-cloud-sdk.tar.gz \
+RUN curl -fsL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_VERSION}-linux-x86_64.tar.gz -o /opt/google-cloud-sdk.tar.gz \
  && cd /opt; tar -xf google-cloud-sdk.tar.gz \
  && rm google-cloud-sdk.tar.gz
 ENV PATH "/opt/google-cloud-sdk/bin:$PATH"

--- a/terraform/executor/Dockerfile-0.11
+++ b/terraform/executor/Dockerfile-0.11
@@ -54,7 +54,7 @@ RUN mkdir -p /root/.terraform.d/plugins \
 
 RUN mkdir -p /root/aiven \
  && for TF_AIVEN_VERSION in $TF_AIVEN_VERSIONS; do \
-      curl -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven-linux_amd64_v${TF_AIVEN_VERSION}" \
+      curl -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven-linux_amd64" \
         -o /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
       chmod +x /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
     done

--- a/terraform/executor/Dockerfile-0.12
+++ b/terraform/executor/Dockerfile-0.12
@@ -48,7 +48,7 @@ RUN mkdir -p $TF_PLUGIN_CACHE_DIR
 
 RUN mkdir -p /root/.terraform.d/plugins \
  && for TF_AIVEN_VERSION in $TF_AIVEN_VERSIONS; do \
-      curl -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven-linux_amd64_v${TF_AIVEN_VERSION}" \
+      curl -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven-linux_amd64" \
         -o /root/.terraform.d/plugins/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
      chmod +x /root/.terraform.d/plugins/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
     done

--- a/terraform/executor/Dockerfile-0.12
+++ b/terraform/executor/Dockerfile-0.12
@@ -54,7 +54,7 @@ RUN mkdir -p /root/aiven \
       chmod +x /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
     done \
  && for TF_AIVEN_VERSION in $TF_AIVEN_VERSIONS; do \
-      curl -f -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven-linux_amd64_v${TF_AIVEN_VERSION}" \
+      curl -f -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven-linux-amd64_v${TF_AIVEN_VERSION}" \
         -o /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
       chmod +x /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
     done

--- a/terraform/executor/Dockerfile-0.12
+++ b/terraform/executor/Dockerfile-0.12
@@ -12,7 +12,8 @@ ARG AWSCLI_VERSION=1.16.294
 ARG HELM2_VERSION=2.16.1
 ARG HELM3_VERSION=3.0.0
 ARG TFSWITCH_VERSION=0.7.737
-ARG TF_AIVEN_VERSIONS="1.0.0 1.0.1 1.0.2 1.0.3 1.0.4 1.0.5 1.0.6 1.0.7 1.0.8 1.0.9 1.0.10 1.0.11 1.0.12 1.0.13 1.0.15 1.0.16 1.0.17 1.0.19"
+ARG TF_AIVEN_VERSIONS="1.0.19 1.0.20 1.1.0"
+ARG TF_OLD_AIVEN_VERSIONS="1.0.0 1.0.1 1.0.2 1.0.3 1.0.4 1.0.5 1.0.6 1.0.7 1.0.8 1.0.9 1.0.10 1.0.11 1.0.12 1.0.13 1.0.15 1.0.16 1.0.17 1.0.18"
 ARG TF_OVO_VERSIONS="1.0.0"
 
 # Terraform environment variables
@@ -36,7 +37,7 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
  && rm -rf /var/lib/apt/lists/*
 
-RUN curl -sL https://github.com/warrensbox/terraform-switcher/releases/download/${TFSWITCH_VERSION}/terraform-switcher_${TFSWITCH_VERSION}_linux_amd64.tar.gz -o tfswitch.tar.gz \
+RUN curl -fsL https://github.com/warrensbox/terraform-switcher/releases/download/${TFSWITCH_VERSION}/terraform-switcher_${TFSWITCH_VERSION}_linux_amd64.tar.gz -o tfswitch.tar.gz \
  && tar -xvf tfswitch.tar.gz \
  && mv tfswitch /usr/local/bin \
  && rm -rf tfswitch \
@@ -46,15 +47,20 @@ RUN curl -sL https://github.com/warrensbox/terraform-switcher/releases/download/
  && tfswitch $DEFAULT_TF_VERSION
 RUN mkdir -p $TF_PLUGIN_CACHE_DIR
 
-RUN mkdir -p /root/.terraform.d/plugins \
+RUN mkdir -p /root/aiven \
+ && for TF_AIVEN_VERSION in $TF_OLD_AIVEN_VERSIONS; do \
+      curl -f -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven-linux_amd64" \
+        -o /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
+      chmod +x /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
+    done
  && for TF_AIVEN_VERSION in $TF_AIVEN_VERSIONS; do \
-      curl -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven-linux_amd64" \
-        -o /root/.terraform.d/plugins/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
-     chmod +x /root/.terraform.d/plugins/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
+      curl -f -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven-linux_amd64_v${TF_AIVEN_VERSION}" \
+        -o /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
+      chmod +x /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
     done
 
 # helm 2
-RUN curl -sL "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM2_VERSION}-linux-amd64.tar.gz" | tar -xzvf- \
+RUN curl -fsL "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM2_VERSION}-linux-amd64.tar.gz" | tar -xzvf- \
  && mv linux-amd64/helm /usr/local/bin/helm2 \
  && rm -rf helm*.tar.gz linux-amd64/ \
  && ln -s /usr/local/bin/helm2 /usr/local/bin/helm \
@@ -62,18 +68,18 @@ RUN curl -sL "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM2_VERSI
 ENV HELM_HOME /root/.helm
 
 # helm 3
-RUN curl -sL "https://get.helm.sh/helm-v${HELM3_VERSION}-linux-amd64.tar.gz" | tar -xzvf- \
+RUN curl -fsL "https://get.helm.sh/helm-v${HELM3_VERSION}-linux-amd64.tar.gz" | tar -xzvf- \
  && mv linux-amd64/helm /usr/local/bin/helm3 \
  && rm -rf helm*.tar.gz linux-amd64/
 
 # ovo provider
 RUN for TF_OVO_VERSION in $TF_OVO_VERSIONS; do \
-      curl -L https://ovo-kafka-user.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
+      curl -f -L https://ovo-kafka-user.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
       && unzip ovo.zip -d /root/.terraform.d/plugins \
       && rm ovo.zip; \
     done
 
-RUN curl -sL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_VERSION}-linux-x86_64.tar.gz -o /opt/google-cloud-sdk.tar.gz \
+RUN curl -fsL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_VERSION}-linux-x86_64.tar.gz -o /opt/google-cloud-sdk.tar.gz \
  && cd /opt; tar -xf google-cloud-sdk.tar.gz \
  && rm google-cloud-sdk.tar.gz
 ENV PATH "/opt/google-cloud-sdk/bin:$PATH"

--- a/terraform/executor/Dockerfile-0.12
+++ b/terraform/executor/Dockerfile-0.12
@@ -52,7 +52,7 @@ RUN mkdir -p /root/aiven \
       curl -f -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven-linux_amd64" \
         -o /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
       chmod +x /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
-    done
+    done \
  && for TF_AIVEN_VERSION in $TF_AIVEN_VERSIONS; do \
       curl -f -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven-linux_amd64_v${TF_AIVEN_VERSION}" \
         -o /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \

--- a/terraform/orb_version.txt
+++ b/terraform/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform@1.6.1
+ovotech/terraform@1.6.2


### PR DESCRIPTION
Using `https://github.com/aiven/terraform-provider-aiven/releases/download/vX/terraform-provider-aiven-linux_amd64` instead of `https://github.com/aiven/terraform-provider-aiven/releases/download/vX/terraform-provider-aiven-linux_amd64_vX` 