### PR TITLE
aws-rotate-keys: avoid printing AccessKeyId to std out

### DIFF
--- a/aws-rotate-keys/orb.yml
+++ b/aws-rotate-keys/orb.yml
@@ -54,7 +54,7 @@ commands:
               aws iam list-access-keys \
                 --user-name << parameters.aws-username >> \
                 --query 'AccessKeyMetadata[0].AccessKeyId' \
-                --output text 2>/dev/null && break
+                --output text >/dev/null 2>/dev/null && break
               echo New token not usable yet, retrying in 10 seconds...
               sleep 10
             done &&

--- a/aws-rotate-keys/orb.yml
+++ b/aws-rotate-keys/orb.yml
@@ -54,7 +54,7 @@ commands:
               aws iam list-access-keys \
                 --user-name << parameters.aws-username >> \
                 --query 'AccessKeyMetadata[0].AccessKeyId' \
-                --output text >/dev/null 2>/dev/null && break
+                --output text 2>&1 >/dev/null && break
               echo New token not usable yet, retrying in 10 seconds...
               sleep 10
             done &&


### PR DESCRIPTION
Avoiding printing AccessKeyId to std out in aws-rotate-keys orb.