### PR TITLE
fix aws-rotate-keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 
 # Orbs follow the conventions:
 #   Directory named the same as the orb
-#   A single Dockerfile in the executor directory
+#   A single Dockerfile in the executor directory (unless you specify publish-docker-image:false)
 #   The orb yaml is in a file name orb.yml
 #   Published in the ovotech namespace
 #   An orb_version.txt file may exists in an orb directory containing the version of the orb.  #     (A new version is only published when the version changes)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,14 +89,18 @@ jobs:
 
               filename=$(basename $path)
 
-              if [[ "$filename" == "Dockerfile" ]]; then
-                  TAG="latest"
-              else
-                  TAG="${filename#"Dockerfile-"}"
+              if [[ -f "$filename" ]]; then
+                if [[ "$filename" == "Dockerfile" ]]; then
+                    TAG="latest"
+                else
+                    TAG="${filename#"Dockerfile-"}"
+                fi
+
+                # update the executor image tag to point at the image that was just published
+                DIGEST=$(<"${ORB}_${TAG}_digest.txt")
+                sed -i -e "s|ovotech/${ORB}:$TAG|$DIGEST|" "/tmp/${ORB}_orb.yml"
               fi
 
-              DIGEST=$(<"${ORB}_${TAG}_digest.txt")
-              sed -i -e "s|ovotech/${ORB}:$TAG|$DIGEST|" "/tmp/${ORB}_orb.yml"
             done
 
             circleci orb publish "/tmp/${ORB}_orb.yml" "ovotech/${ORB}@dev:$CIRCLE_BRANCH" --token "$CIRCLECI_TOKEN"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       path:
         type: string
         description: The path to the orb
-      publish-docker:
+      publish-docker-image:
         type: boolean
         description: |
           Some orbs actions don't require us to maintain an executor image; set this to false if the orb uses existing public images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,9 +103,12 @@ jobs:
 
             done
 
+            echo "Publishing branch development-version: ovotech/${ORB}@dev:$CIRCLE_BRANCH"
             circleci orb publish "/tmp/${ORB}_orb.yml" "ovotech/${ORB}@dev:$CIRCLE_BRANCH" --token "$CIRCLECI_TOKEN"
 
             if [ "$CIRCLE_BRANCH" = "master" ]; then
+              echo "Publishing master to ovotech/${ORB}"
+
               if ! circleci orb source "ovotech/${ORB}" > "/tmp/${ORB}_current.yml"; then
                 # This is the first version
                 circleci orb publish promote "ovotech/${ORB}@dev:$CIRCLE_BRANCH" major --token "$CIRCLECI_PROD_TOKEN"
@@ -127,6 +130,10 @@ jobs:
                 # This is a new version
                 circleci orb publish increment "/tmp/${ORB}_orb.yml" "ovotech/${ORB}" patch --token "$CIRCLECI_PROD_TOKEN"
               fi
+            elif
+              echo "Orb can now be tested using the following circleci config"
+              echo "  orbs:"
+              echo "    ${ORB}: ovotech/${ORB}@dev:$CIRCLE_BRANCH"
             fi
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
           steps:
             - run:
                 name: docker build << parameters.path >>
+                # language=bash
                 command: |
                   docker login --username $DOCKERHUB_USERNAME --password $DOCKERHUB_PASSWORD
 
@@ -80,6 +81,7 @@ jobs:
                   done
       - run:
           name: Publish << parameters.path >> orb
+          # language=bash
           command: |
             readonly ORB="<< parameters.path >>"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ jobs:
                 # This is a new version
                 circleci orb publish increment "/tmp/${ORB}_orb.yml" "ovotech/${ORB}" patch --token "$CIRCLECI_PROD_TOKEN"
               fi
-            elif
+            else
               echo "Orb can now be tested using the following circleci config"
               echo "  orbs:"
               echo "    ${ORB}: ovotech/${ORB}@dev:$CIRCLE_BRANCH"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
             done
 
             echo "Publishing branch development-version: ovotech/${ORB}@dev:$CIRCLE_BRANCH"
-            circleci orb publish "/tmp/${ORB}_orb.yml" "ovotech/${ORB}@dev:$CIRCLE_BRANCH" --token "$CIRCLECI_TEST_TOKEN"
+            circleci orb publish "/tmp/${ORB}_orb.yml" "ovotech/${ORB}@dev:$CIRCLE_BRANCH" --token "$CIRCLECI_TOKEN"
 
             if [ "$CIRCLE_BRANCH" = "master" ]; then
               echo "Publishing master to ovotech/${ORB}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
             done
 
             echo "Publishing branch development-version: ovotech/${ORB}@dev:$CIRCLE_BRANCH"
-            circleci orb publish "/tmp/${ORB}_orb.yml" "ovotech/${ORB}@dev:$CIRCLE_BRANCH" --token "$CIRCLECI_TOKEN"
+            circleci orb publish "/tmp/${ORB}_orb.yml" "ovotech/${ORB}@dev:$CIRCLE_BRANCH" --token "$CIRCLECI_TEST_TOKEN"
 
             if [ "$CIRCLE_BRANCH" = "master" ]; then
               echo "Publishing master to ovotech/${ORB}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,49 +29,56 @@ jobs:
       path:
         type: string
         description: The path to the orb
+      publish-docker:
+        type: boolean
+        description: |
+          Some orbs actions don't require us to maintain an executor image; set this to false if the orb uses existing public images
+        default: true
     docker:
       - image: 361339499037.dkr.ecr.eu-west-1.amazonaws.com/pe-orbs:latest
     steps:
       - checkout
       - setup_remote_docker:
           version: 17.11.0-ce
-      - run:
-          name: docker build << parameters.path >>
-          command: |
-            docker login --username $DOCKERHUB_USERNAME --password $DOCKERHUB_PASSWORD
+      - when:
+          condition: <<parameters.publish-docker-image>>
+          steps:
+            - run:
+              name: docker build << parameters.path >>
+              command: |
+                docker login --username $DOCKERHUB_USERNAME --password $DOCKERHUB_PASSWORD
 
-            readonly ORB="<< parameters.path >>"
+                readonly ORB="<< parameters.path >>"
 
-            for path in $ORB/executor/Dockerfile*; do
+                for path in $ORB/executor/Dockerfile*; do
 
-              filename=$(basename $path)
+                  filename=$(basename $path)
 
-              if [[ "$filename" == "Dockerfile" ]]; then
-                  TAG="latest"
-                  BUILD_TAG="$(date "+%d-%m-%Y")"
-              else
-                  TAG="${filename#"Dockerfile-"}"
-                  BUILD_TAG="${TAG}_$(date "+%d-%m-%Y")"
-              fi
+                  if [[ "$filename" == "Dockerfile" ]]; then
+                      TAG="latest"
+                      BUILD_TAG="$(date "+%d-%m-%Y")"
+                  else
+                      TAG="${filename#"Dockerfile-"}"
+                      BUILD_TAG="${TAG}_$(date "+%d-%m-%Y")"
+                  fi
 
-              docker build --tag "ovotech/${ORB}:${BUILD_TAG}" \
-              --label org.label-schema.vcs-ref="$CIRCLE_SHA1" \
-              --label org.label-schema.vcs-url="$CIRCLE_REPOSITORY_URL" \
-              --label org.label-schema.schema-version="1.0" \
-              --file $path \
-              "${ORB}/executor"
+                  docker build --tag "ovotech/${ORB}:${BUILD_TAG}" \
+                  --label org.label-schema.vcs-ref="$CIRCLE_SHA1" \
+                  --label org.label-schema.vcs-url="$CIRCLE_REPOSITORY_URL" \
+                  --label org.label-schema.schema-version="1.0" \
+                  --file $path \
+                  "${ORB}/executor"
 
-              docker push "ovotech/${ORB}:${BUILD_TAG}"
+                  docker push "ovotech/${ORB}:${BUILD_TAG}"
 
-              DIGEST=$(docker image inspect --format="{{index .RepoDigests 0}}" "ovotech/${ORB}:${BUILD_TAG}")
-              echo $DIGEST > "${ORB}_${TAG}_digest.txt"
+                  DIGEST=$(docker image inspect --format="{{index .RepoDigests 0}}" "ovotech/${ORB}:${BUILD_TAG}")
+                  echo $DIGEST > "${ORB}_${TAG}_digest.txt"
 
-              if [ "$CIRCLE_BRANCH" = "master" ]; then
-                  docker tag "ovotech/${ORB}:${BUILD_TAG}" "ovotech/${ORB}:${TAG}"
-                  docker push "ovotech/${ORB}:${TAG}"
-              fi
-            done
-
+                  if [ "$CIRCLE_BRANCH" = "master" ]; then
+                      docker tag "ovotech/${ORB}:${BUILD_TAG}" "ovotech/${ORB}:${TAG}"
+                      docker push "ovotech/${ORB}:${TAG}"
+                  fi
+                done
       - run:
           name: Publish << parameters.path >> orb
           command: |
@@ -131,6 +138,7 @@ workflows:
       - publish_orb:
           name: aws-rotate-keys
           path: aws-rotate-keys
+          publish-docker: false
           requires:
             - validate_orbs
       - publish_orb:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,41 +43,41 @@ jobs:
           condition: <<parameters.publish-docker-image>>
           steps:
             - run:
-              name: docker build << parameters.path >>
-              command: |
-                docker login --username $DOCKERHUB_USERNAME --password $DOCKERHUB_PASSWORD
+                name: docker build << parameters.path >>
+                command: |
+                  docker login --username $DOCKERHUB_USERNAME --password $DOCKERHUB_PASSWORD
 
-                readonly ORB="<< parameters.path >>"
+                  readonly ORB="<< parameters.path >>"
 
-                for path in $ORB/executor/Dockerfile*; do
+                  for path in $ORB/executor/Dockerfile*; do
 
-                  filename=$(basename $path)
+                    filename=$(basename $path)
 
-                  if [[ "$filename" == "Dockerfile" ]]; then
-                      TAG="latest"
-                      BUILD_TAG="$(date "+%d-%m-%Y")"
-                  else
-                      TAG="${filename#"Dockerfile-"}"
-                      BUILD_TAG="${TAG}_$(date "+%d-%m-%Y")"
-                  fi
+                    if [[ "$filename" == "Dockerfile" ]]; then
+                        TAG="latest"
+                        BUILD_TAG="$(date "+%d-%m-%Y")"
+                    else
+                        TAG="${filename#"Dockerfile-"}"
+                        BUILD_TAG="${TAG}_$(date "+%d-%m-%Y")"
+                    fi
 
-                  docker build --tag "ovotech/${ORB}:${BUILD_TAG}" \
-                  --label org.label-schema.vcs-ref="$CIRCLE_SHA1" \
-                  --label org.label-schema.vcs-url="$CIRCLE_REPOSITORY_URL" \
-                  --label org.label-schema.schema-version="1.0" \
-                  --file $path \
-                  "${ORB}/executor"
+                    docker build --tag "ovotech/${ORB}:${BUILD_TAG}" \
+                    --label org.label-schema.vcs-ref="$CIRCLE_SHA1" \
+                    --label org.label-schema.vcs-url="$CIRCLE_REPOSITORY_URL" \
+                    --label org.label-schema.schema-version="1.0" \
+                    --file $path \
+                    "${ORB}/executor"
 
-                  docker push "ovotech/${ORB}:${BUILD_TAG}"
+                    docker push "ovotech/${ORB}:${BUILD_TAG}"
 
-                  DIGEST=$(docker image inspect --format="{{index .RepoDigests 0}}" "ovotech/${ORB}:${BUILD_TAG}")
-                  echo $DIGEST > "${ORB}_${TAG}_digest.txt"
+                    DIGEST=$(docker image inspect --format="{{index .RepoDigests 0}}" "ovotech/${ORB}:${BUILD_TAG}")
+                    echo $DIGEST > "${ORB}_${TAG}_digest.txt"
 
-                  if [ "$CIRCLE_BRANCH" = "master" ]; then
-                      docker tag "ovotech/${ORB}:${BUILD_TAG}" "ovotech/${ORB}:${TAG}"
-                      docker push "ovotech/${ORB}:${TAG}"
-                  fi
-                done
+                    if [ "$CIRCLE_BRANCH" = "master" ]; then
+                        docker tag "ovotech/${ORB}:${BUILD_TAG}" "ovotech/${ORB}:${TAG}"
+                        docker push "ovotech/${ORB}:${TAG}"
+                    fi
+                  done
       - run:
           name: Publish << parameters.path >> orb
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,7 @@ version: 2.1
 #   A single Dockerfile in the executor directory
 #   The orb yaml is in a file name orb.yml
 #   Published in the ovotech namespace
-#   An orb_version.txt file may exists in an orb directory containing the version of the orb.
-#     (A new version is only published when the version changes)
+#   An orb_version.txt file may exists in an orb directory containing the version of the orb.  #     (A new version is only published when the version changes)
 
 jobs:
   validate_orbs:
@@ -138,7 +137,7 @@ workflows:
       - publish_orb:
           name: aws-rotate-keys
           path: aws-rotate-keys
-          publish-docker: false
+          publish-docker-image: false
           requires:
             - validate_orbs
       - publish_orb:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,6 @@ version: 2.1
 
 # Reuse a common job for publishing each orb
 
-# Orbs follow the conventions:
-#   Directory named the same as the orb
-#   A single Dockerfile in the executor directory (unless you specify publish-docker-image:false)
-#   The orb yaml is in a file name orb.yml
-#   Published in the ovotech namespace
-#   An orb_version.txt file may exists in an orb directory containing the version of the orb.  #     (A new version is only published when the version changes)
-
 jobs:
   validate_orbs:
     description: Validate orbs

--- a/README.md
+++ b/README.md
@@ -1,8 +1,26 @@
+[![CircleCI](https://circleci.com/gh/ovotech/circleci-orbs.svg?style=shield&circle-token=ae0a459eabe5a6b454eab8e241a516fd1a212e8c)](https://app.circleci.com/pipelines/github/ovotech/circleci-orbs)
+
 # CircleCI Orbs
 
 This repo contains public circleci orbs in the ovotech namespace.
 
-Published orbs:
+## Contributing
+
+Orbs follow the conventions:
+
+* **Directory** named the **same** as the orb
+
+* A single Dockerfile in the executor directory (unless you specify publish-docker-image:false)
+
+* The orb yaml is in a file name `orb.yml`
+
+* Published in the ovotech namespace
+
+* An `orb_version.txt` file may exist in an orb directory containing the version of the orb. (A new version is only published when the version changes)
+
+
+## Published Orbs
+
  - [ovotech/aws-get-parameters@1](aws-get-parameters) - Get parameters from AWS Parameter Store.
  - [ovotech/aws-rotate-keys@1](aws-rotate-keys) - Rotate AWS access keys and update corresponding CircleCI environment variables.
  - [ovotech/clair-scanner@1](clair-scanner) - Scan Docker images for vulnerabilities.

--- a/aws-rotate-keys/README.md
+++ b/aws-rotate-keys/README.md
@@ -35,8 +35,6 @@ jobs:
       - rotate-aws-keys/rotate:
           aws-username: circleci-user
           circleci-token: $CIRCLECI_TOKEN
-          aws-access-key-id-var: AWS_ACCESS_KEY_ID
-          aws-secret-access-key-var: AWS_SECRET_ACCESS_KEY
 
 workflows:
   version: 2
@@ -61,11 +59,6 @@ jobs:
   rotate-aws-keys:
     executor: rotate-aws-keys/default
     steps:
-      - run:
-          command: |
-            export AWS_ACCESS_KEY_ID=$PROD_AWS_ACCESS_KEY_ID
-            export AWS_SECRET_ACCESS_KEY=$PROD_AWS_SECRET_ACCESS_KEY
-            export AWS_DEFAULT_REGION=$PROD_AWS_DEFAULT_REGION
       - rotate-aws-keys/rotate:
           aws-username: circleci-user
           circleci-token: $CIRCLECI_TOKEN

--- a/aws-rotate-keys/executor/Dockerfile
+++ b/aws-rotate-keys/executor/Dockerfile
@@ -1,3 +1,0 @@
-FROM circleci/python:3-stretch
-
-RUN sudo pip install awscli --upgrade

--- a/aws-rotate-keys/orb.yml
+++ b/aws-rotate-keys/orb.yml
@@ -1,11 +1,11 @@
 version: 2.1
 description: An orb to rotate AWS keys
 
+orbs:
+  aws-cli: circleci/aws-cli@1
+
 executors:
-  default:
-    description: Default executor
-    docker:
-      - image: ovotech/aws-rotate-keys:latest
+  default: aws-cli/default
 
 commands:
   rotate:
@@ -30,6 +30,10 @@ commands:
           you will use to hold this value, i.e. AWS_SECRET_ACCESS_KEY.
         default: AWS_SECRET_ACCESS_KEY
     steps:
+      - aws-cli/setup:
+          aws-access-key-id: << parameters.aws-access-key-id-var >>
+          aws-secret-access-key: << parameters.aws-secret-access-key-var >>
+          configure-default-region: false
       - run:
           name: Rotate AWS keys
           command: |


### PR DESCRIPTION
The aws-rotate-keys repo did not exist in dockerhub

* Modify circleci config to make publishing to dockerhub optional
* Update aws-rotate-keys to use public images maintained by circleci
* Update the readme (added a badge for flair)