### PR TITLE
Changes for interpolation of var names in aws rotate keys

### DIFF
--- a/aws-rotate-keys/README.md
+++ b/aws-rotate-keys/README.md
@@ -59,6 +59,11 @@ jobs:
   rotate-aws-keys:
     executor: rotate-aws-keys/default
     steps:
+      - run:
+          name: Set AWS environment to PROD
+          command: |
+            echo 'export AWS_ACCESS_KEY_ID=$PROD_AWS_ACCESS_KEY_ID' >> $BASH_ENV
+            echo 'export AWS_SECRET_ACCESS_KEY=$PROD_AWS_SECRET_ACCESS_KEY' >> $BASH_ENV
       - rotate-aws-keys/rotate:
           aws-username: circleci-user
           circleci-token: $CIRCLECI_TOKEN

--- a/aws-rotate-keys/orb.yml
+++ b/aws-rotate-keys/orb.yml
@@ -31,14 +31,12 @@ commands:
         default: AWS_SECRET_ACCESS_KEY
     steps:
       - aws-cli/install:
-          # This only install the cli if it is missing from $PATH
+          # This only installs the cli if it is missing from $PATH
           version: '2'
       - run:
           name: Rotate AWS keys
           command: |
-            # Configure the credentials needed to access AWS (not using aws-cli/setup since it precludes interpolation via its usage of the env_var_name type)
-            [[ -z "$AWS_ACCESS_KEY_ID" ]] && export AWS_ACCESS_KEY_ID=<< parameters.aws-access-key-id-var >>
-            [[ -z "$AWS_SECRET_ACCESS_KEY" ]] && export AWS_SECRET_ACCESS_KEY=<< parameters.aws-secret-access-key-var >>
+            # Assumes that AWS credentials have already been configured
             old_access_key_id=`aws iam list-access-keys --user-name << parameters.aws-username >> --query 'AccessKeyMetadata[0].AccessKeyId' --output text` &&
             create_access_key_output=`aws iam create-access-key --user-name << parameters.aws-username >>` &&
             new_access_key_id=`echo $create_access_key_output | jq -r -e '.AccessKey.AccessKeyId'` &&

--- a/aws-rotate-keys/orb.yml
+++ b/aws-rotate-keys/orb.yml
@@ -2,7 +2,7 @@ version: 2.1
 description: An orb to rotate AWS keys
 
 orbs:
-  aws-cli: circleci/aws-cli@1
+  aws-cli: circleci/aws-cli@1.0.0
 
 executors:
   default: aws-cli/default
@@ -30,13 +30,15 @@ commands:
           you will use to hold this value, i.e. AWS_SECRET_ACCESS_KEY.
         default: AWS_SECRET_ACCESS_KEY
     steps:
-      - aws-cli/setup:
-          aws-access-key-id: << parameters.aws-access-key-id-var >>
-          aws-secret-access-key: << parameters.aws-secret-access-key-var >>
-          configure-default-region: false
+      - aws-cli/install:
+          # This only install the cli if it is missing from $PATH
+          version: '2'
       - run:
           name: Rotate AWS keys
           command: |
+            # Configure the credentials needed to access AWS (not using aws-cli/setup since it precludes interpolation via usage of env_var_name type
+            [[ -z "$AWS_ACCESS_KEY_ID" ]] && << parameters.aws-access-key-id-var >>
+            [[ -z "$AWS_SECRET_ACCESS_KEY" ]] && << parameters.aws-access-key-id-var >>
             old_access_key_id=`aws iam list-access-keys --user-name << parameters.aws-username >> --query 'AccessKeyMetadata[0].AccessKeyId' --output text` &&
             create_access_key_output=`aws iam create-access-key --user-name << parameters.aws-username >>` &&
             new_access_key_id=`echo $create_access_key_output | jq -r -e '.AccessKey.AccessKeyId'` &&

--- a/aws-rotate-keys/orb.yml
+++ b/aws-rotate-keys/orb.yml
@@ -37,8 +37,8 @@ commands:
           name: Rotate AWS keys
           command: |
             # Configure the credentials needed to access AWS (not using aws-cli/setup since it precludes interpolation via its usage of the env_var_name type)
-            [[ -z "$AWS_ACCESS_KEY_ID" ]] && << parameters.aws-access-key-id-var >>
-            [[ -z "$AWS_SECRET_ACCESS_KEY" ]] && << parameters.aws-access-key-id-var >>
+            [[ -z "$AWS_ACCESS_KEY_ID" ]] && export AWS_ACCESS_KEY_ID=<< parameters.aws-access-key-id-var >>
+            [[ -z "$AWS_SECRET_ACCESS_KEY" ]] && export AWS_SECRET_ACCESS_KEY=<< parameters.aws-access-key-id-var >>
             old_access_key_id=`aws iam list-access-keys --user-name << parameters.aws-username >> --query 'AccessKeyMetadata[0].AccessKeyId' --output text` &&
             create_access_key_output=`aws iam create-access-key --user-name << parameters.aws-username >>` &&
             new_access_key_id=`echo $create_access_key_output | jq -r -e '.AccessKey.AccessKeyId'` &&

--- a/aws-rotate-keys/orb.yml
+++ b/aws-rotate-keys/orb.yml
@@ -36,7 +36,7 @@ commands:
       - run:
           name: Rotate AWS keys
           command: |
-            # Configure the credentials needed to access AWS (not using aws-cli/setup since it precludes interpolation via usage of env_var_name type
+            # Configure the credentials needed to access AWS (not using aws-cli/setup since it precludes interpolation via its usage of the env_var_name type)
             [[ -z "$AWS_ACCESS_KEY_ID" ]] && << parameters.aws-access-key-id-var >>
             [[ -z "$AWS_SECRET_ACCESS_KEY" ]] && << parameters.aws-access-key-id-var >>
             old_access_key_id=`aws iam list-access-keys --user-name << parameters.aws-username >> --query 'AccessKeyMetadata[0].AccessKeyId' --output text` &&

--- a/aws-rotate-keys/orb.yml
+++ b/aws-rotate-keys/orb.yml
@@ -38,7 +38,7 @@ commands:
           command: |
             # Configure the credentials needed to access AWS (not using aws-cli/setup since it precludes interpolation via its usage of the env_var_name type)
             [[ -z "$AWS_ACCESS_KEY_ID" ]] && export AWS_ACCESS_KEY_ID=<< parameters.aws-access-key-id-var >>
-            [[ -z "$AWS_SECRET_ACCESS_KEY" ]] && export AWS_SECRET_ACCESS_KEY=<< parameters.aws-access-key-id-var >>
+            [[ -z "$AWS_SECRET_ACCESS_KEY" ]] && export AWS_SECRET_ACCESS_KEY=<< parameters.aws-secret-access-key-var >>
             old_access_key_id=`aws iam list-access-keys --user-name << parameters.aws-username >> --query 'AccessKeyMetadata[0].AccessKeyId' --output text` &&
             create_access_key_output=`aws iam create-access-key --user-name << parameters.aws-username >>` &&
             new_access_key_id=`echo $create_access_key_output | jq -r -e '.AccessKey.AccessKeyId'` &&


### PR DESCRIPTION
https://github.com/ovotech/circleci-orbs/pull/115 was supposed to just update the image being used, but it actually modified the behavior

a new feature "use << parameters.aws-secret-access-key-var >> as access credentials" does not work, because you run afoul of interpolation (which users may well want to use)

it was a misguided feature anyway so that is removed, the feature rolled back, the behavior is as before

changes in this PR:

- Stop passing strings to aws-cli/setup when it expects the circleci type `env_var_name`     
- Pin the version of the orb that is a dependency, to prevent surprises in the future
