### PR TITLE
Fixes ovotech/circleci-orbs#89

### DIFF
--- a/clair-scanner/scan.sh
+++ b/clair-scanner/scan.sh
@@ -37,7 +37,7 @@ function scan() {
         --clair=http://"$clair_ip":6060 \
         -t "<< parameters.severity_threshold >>" \
         --report "/$sanitised_image_filename" \
-        --log "/log.json" ${WHITELIST:+"-x"}
+        --log "/log.json" ${WHITELIST}
         --reportAll=true \
         --exit-when-no-features=false \
         "$image")

--- a/clair-scanner/scan.sh
+++ b/clair-scanner/scan.sh
@@ -37,7 +37,7 @@ function scan() {
         --clair=http://"$clair_ip":6060 \
         -t "<< parameters.severity_threshold >>" \
         --report "/$sanitised_image_filename" \
-        --log "/log.json" ${WHITELIST}
+        --log "/log.json" $WHITELIST
         --reportAll=true \
         --exit-when-no-features=false \
         "$image")


### PR DESCRIPTION
Removes the `-x` command line option for `clair-scanner`. This is not one of the options documented at https://github.com/arminc/clair-scanner/blob/master/README.md. Testing locally confirms this resolves the error in issue #89.

Output before fix:
```
latest: Pulling from repo
Digest: sha256:--->8---
Status: Image is up to date for image:latest
Error: incorrect usage

Usage: clair-scanner [OPTIONS] IMAGE

Scan local Docker images for vulnerabilities with Clair

Arguments:
  IMAGE=""     Name of the Docker image to scan

Options:
  -w, --whitelist=""                    Path to the whitelist file
  -t, --threshold="Unknown"             CVE severity threshold. Valid values; 'Defcon1', 'Critical', 'High', 'Medium', 'Low', 'Negligible', 'Unknown'
  -c, --clair="http://127.0.0.1:6060"   Clair URL
  --ip="localhost"                      IP address where clair-scanner is running on
  -l, --log=""                          Log to a file
  --all, --reportAll=true               Display all vulnerabilities, even if they are approved
  -r, --report=""                       Report output file, as JSON
  -q, --quiet=false                     Quiets ASCII table output
  --exit-when-no-features=false         Exit with status code 5 when no features are found for a particular image
Unknown clair-scanner return code 2.

```

Output after fix:
```
latest: Pulling from repo
Digest: sha256:--->8---
Status: Image is up to date for image:latest
2020/04/26 22:43:53 [INFO] ▶ Start clair-scanner
2020/04/26 22:44:27 [INFO] ▶ Server listening on port 9279
2020/04/26 22:44:27 [INFO] ▶ Analyzing
--->8---
2020/04/26 22:44:35 [WARN] ▶ Image [image:latest] contains 1 total vulnerabilities
2020/04/26 22:44:35 [INFO] ▶ Image [image:latest] contains NO unapproved vulnerabilities
+----------+--------------------+--------------+-----------------+--------------------------------------------------------------+
| STATUS   | CVE SEVERITY       | PACKAGE NAME | PACKAGE VERSION | CVE DESCRIPTION                                              |
+----------+--------------------+--------------+-----------------+--------------------------------------------------------------+
| Approved | High CVE-2016-4074 | jq           | 1.6-r1          |                                                              |
|          |                    |              |                 | https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4074 |
+----------+--------------------+--------------+-----------------+--------------------------------------------------------------+
No unapproved vulnerabilities
```