### PR TITLE
Add TFENV override of 0.11 to tfmask

### DIFF
--- a/terraform/executor/Dockerfile-0.11
+++ b/terraform/executor/Dockerfile-0.11
@@ -103,5 +103,6 @@ RUN pip3 install awscli==$AWSCLI_VERSION
 
 COPY --from=tfmask /go/tfmask/release/tfmask /usr/local/bin/tfmask
 ENV TFMASK_RESOURCES_REGEX="(?i)^(random_id|kubernetes_secret|acme_certificate).*$"
+ENV TFENV="0.11"
 
 ENTRYPOINT ["/usr/local/bin/terraform"]


### PR DESCRIPTION
in the 0.11 dockerfile we just grab the latest:

```
RUN git clone https://github.com/cloudposse/tfmask.git
RUN cd tfmask && make && make go/build
```

when my branch was merged into [cloudposse/tfmask](https://github.com/cloudposse/tfmask), the cloudposse wanted the default terraform version to be switched to 0.12. So this change is just to ensure future builds of the 0.11 image has the `TFENV` env var set.