### PR TITLE
Release terraform 1.6.6

### DIFF
--- a/terraform/CHANGELOG.md
+++ b/terraform/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
 not listed.
 
+## ovotech/terraform@1.6.6
+### Changed
+- Added `TFENV` env var to 0.11 Docker image, as `tfmask` now defaults to tf 0.12
+
 ## ovotech/terraform@1.6.5
 ### Changed
 - Updated executors to include:

--- a/terraform/orb_version.txt
+++ b/terraform/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform@1.6.5
+ovotech/terraform@1.6.6


### PR DESCRIPTION
https://circleci.com/orbs/registry/orb/ovotech/terraform#executors-terraform-0_12 is still showing an old image, hence I believe we need to release this