### PR TITLE
Add tools-install orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,7 @@ jobs:
 
             tools/include.py "${ORB}/orb.yml" > "/tmp/${ORB}_orb.yml"
 
+            shopt -s nullglob   # allow orbs to have no dockerfile
             for path in $ORB/executor/Dockerfile*; do
 
               filename=$(basename $path)
@@ -161,5 +162,10 @@ workflows:
       - publish_orb:
           name: rac-gcp-deploy
           path: rac-gcp-deploy
+          requires:
+            - validate_orbs
+      - publish_orb:
+          name: tools-install
+          path: tools-install
           requires:
             - validate_orbs

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Orbs follow the conventions:
  - [ovotech/clair-scanner@1](clair-scanner) - Scan Docker images for vulnerabilities.
  - [ovotech/rac-gcp-deply@1](rac-gcp-deploy) - Deploy Scala services to a Kubernetes cluster running in Google Cloud.
  - [ovotech/terraform@1](terraform) - Plan and apply Terraform modules.
+ - [ovotech/tools-install@1](tools-install) - Download and unpack tools archives
  
  Other orbs in the ovotech namespace:
  - [ovotech/shipit@1](https://github.com/ovotech/pe-orbs/tree/master/shipit) - Run shipit and record deployments to https://shipit.ovotech.org.uk.

--- a/tools-install/README.md
+++ b/tools-install/README.md
@@ -1,0 +1,17 @@
+# Tools install
+
+Orb to make it easier to extract tools from archives.
+
+```yaml
+version: 2.1
+orbs:
+  tools-install: ovotech/tools-install@1
+jobs:
+  build:
+    machine: true
+    steps:
+      - tools-install/do:
+          archive_url: https://get.helm.sh/helm-v3.2.2-linux-amd64.tar.gz
+          symlink_source: linux-amd64/helm
+      - run: helm version
+```

--- a/tools-install/orb.yaml
+++ b/tools-install/orb.yaml
@@ -1,0 +1,62 @@
+version: 2.1
+description: |
+  An orb to download and unpack tools archives.
+
+  Often you require some extra tools, not included in CircleCI images, but would like to
+  avoid overhead of managing your custom build image.
+
+  Often tools are distributed as an archive with a statically linked executable file in it,
+  This orb makes it easy to download, unpack such archives and make executable inside
+  available in the PATH.
+
+commands:
+  do:
+    parameters:
+      archive_url:
+        type: string
+        description: "URL of archive to download and unpack"
+      download_basedir:
+        type: string
+        default: "/tmp/cached_tools"
+        description: "Base directory to unpack archive to"
+      symlink_destdir:
+        type: string
+        default: "~/bin"
+        description: "Directory where to create symlink. Should be in PATH env var for best results"
+      symlink_source:
+        type: string
+        description: "Path to the binary inside archive to create symlink for"
+      symlink_destination_name:
+        type: string
+        default: ""
+        description: "Symlink name to create. Defaults to basename of symlink source if empty."
+    steps:
+      - run:
+          name: Installing <<parameters.archive_url>>
+          command: |
+            DEST_DIR=$(mktemp -d -p <<parameters.download_basedir>>)
+            [[ -d ${DEST_DIR} ]] || {
+              mkdir -p "${DEST_DIR}"
+              curl -q -f -L  << parameters.archive_url>> | tar -C "${DEST_DIR}" -xzf -
+            }
+
+            SYMLINK_NAME="<<parameters.symlink_destination_name>>"
+            SYMLINK_NAME="${SYMLINK_NAME:-$(basename <<parameters.symlink_source>>)}"
+            mkdir -p << parameters.symlink_destdir >>
+            ln -f -s "${DEST_DIR}/<<parameters.symlink_source>>" <<parameters.symlink_destdir>>/"${SYMLINK_NAME}"
+
+examples:
+  install_helm:
+    description: Downloads helm and creates ~/bin/helm symlink to an executable
+    usage:
+      version: 2.1
+      orbs:
+        tools-install: ovotech/tools-install@1
+      jobs:
+        build:
+          machine: true
+          steps:
+            - tools-install/do:
+                archive_url: https://get.helm.sh/helm-v3.2.2-linux-amd64.tar.gz
+                symlink_source: linux-amd64/helm
+            - run: helm version


### PR DESCRIPTION
Often you require some extra tools, not included in CircleCI images, but would like to
avoid overhead of managing your custom build image.

Often tools are distributed as an archive with a statically linked executable file in it,
This orb makes it easy to download, unpack such archives and make executable inside
available in the PATH.