### PR TITLE
with-git-deploy-key orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,3 +169,7 @@ workflows:
           path: tools-install
           requires:
             - validate_orbs
+      - publish_orb:
+          name: with-git-deploy-key
+          path: with-git-deploy-key
+          publish-docker-image: false

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Orbs follow the conventions:
  - [ovotech/rac-gcp-deply@1](rac-gcp-deploy) - Deploy Scala services to a Kubernetes cluster running in Google Cloud.
  - [ovotech/terraform@1](terraform) - Plan and apply Terraform modules.
  - [ovotech/tools-install@1](tools-install) - Download and unpack tools archives
+ - [ovotech/with-git-deploy-key@1](with-git-deploy-key) - Execute Git operations on another repo selecting specific public key.
  
  Other orbs in the ovotech namespace:
  - [ovotech/shipit@1](https://github.com/ovotech/pe-orbs/tree/master/shipit) - Run shipit and record deployments to https://shipit.ovotech.org.uk.

--- a/with-git-deploy-key/README.md
+++ b/with-git-deploy-key/README.md
@@ -1,0 +1,51 @@
+# Selecting specific SSH key when invoking Git
+
+Sometimes you need to execute git operations on another private repository. 
+When accessing github over SSH, git uses first available key, which is usually the key
+for your "main" repository, and that key is a [Github deploy key](https://developer.github.com/v3/guides/managing-deploy-keys/).
+This key is accepted by SSH, so SSH stops trying other keys found in ssh-agent, but rejected by Github auth
+as not having sufficient permissions for another repository.
+
+This orb provides a command, which configures Git to use specific
+key found in ssh-agent. Key is identified by a fingerprint and needs to be
+present in the agent already. On a CircleCI you can add more keys to the ssh-agent
+by creating aditional SSH keys in the project settings.
+
+
+## Example
+
+Prepare key, add it to Github and CircleCI:
+
+ 1. Create an ssh key in pem format: `ssh-keygen -t ecdsa -m pem newkey`
+ 2. Add `newkey.pub` to the Github project you plan to access from CircleCI job
+ 3. Go to CircleCI project settings -> SSH keys ->  Additional SSH Keys -> Add SSH Key.
+    Use empty hostname when prompted.
+ 4. Take a note of a key fingerprint, it will be used to identify this key later.
+
+
+Use this Orb to invoke git commands using this key:
+
+```yaml
+version: 2.1
+orbs:
+  with-git-deploy-key: ovotech/with-git-deploy-key@1
+jobs:
+  gitops_image_update:
+    parameters:
+      image: {type: string}
+    steps:
+    - with-git-deploy-key/do:
+        # Use fingerprint from CircleCI UI here
+        ssh_key_fingerprint: "80:96:c0:86:7f:4f:7f:07:31:0d:69:bb:fb:14:90:3d"
+        git_steps:
+          - run: git clone git@github.com:myorg/gitops.git gitops
+          - run:
+              name: "Gitops: update image"
+              command: |
+                cd gitops
+                #
+                # Update image here, for instance 'kustomize edit set image << parameters.image >>'
+                #
+                git commit -m "CircleCI deploy ${CIRCLE_PROJECT_REPONAME}" -m  "Build URL: ${CIRCLE_BUILD_URL}" -a
+                git push
+```

--- a/with-git-deploy-key/orb.yml
+++ b/with-git-deploy-key/orb.yml
@@ -1,0 +1,73 @@
+version: 2.1
+description: |
+  Orb provides helper command to execute git operations using sepcific
+  SSH key from an ssh agent. 
+
+  Useful when you need to work with another private repository accessible by SSH.
+
+  SSH key is identified by a fingerprint and must be available in an SSH agent and
+  can be added in CircleCI project settings.
+
+commands:
+  do:
+    description: |
+      Executes git commands selecting sepcific SSH key from an ssh agent.
+
+      This command restores $BASH_ENV to the state, before it started, therefore
+      if your `git_steps` modify $BASH_ENV, these changes will be revereted.
+    parameters:
+      git_steps:
+        type: steps
+        description: "Steps, usually git clone/push commands, to execute using an SSH key selected by the ssh_key_fingerprint param."
+        default: []
+      ssh_key_fingerprint:
+        type: string
+        description: "SSH Public key fingerprint to use. Must be exactly as seen in CircleCI UI. Example aa:bb:cc:dd:..."
+    steps:
+      - run:
+          name: "Configuring SSH environment"
+          command: |
+            f=$(mktemp)
+            ssh-add -L | while read -r l; do
+              if [[ $(ssh-keygen -l -E md5 -f <(echo "$l")) =~ "<< parameters.ssh_key_fingerprint >>" ]]; then
+                echo "$l" >"$f"; break
+              fi
+            done
+            [[ -s "$f" ]] || { >&2 echo "Fingerprint not found, did you add key to your CircleCI project settings?"; exit 1; }
+
+            oldenv=$(mktemp)
+            [[ ! -f "$BASH_ENV" ]] || cp "$BASH_ENV" $oldenv
+            echo "export GIT_SSH_COMMAND='ssh -i $f'" >> $BASH_ENV
+            echo "export ORB_GIT_CLONE_WITH_KEY_OLD_ENV=$oldenv" >> $BASH_ENV
+      - steps: << parameters.git_steps >>
+      - run:
+          name: "Restore SSH environment"
+          command: |
+            mv "${ORB_GIT_CLONE_WITH_KEY_OLD_ENV:?}" "$BASH_ENV"
+
+examples:
+  gitops:
+    description: Clone and push to another private Git repository
+    usage:
+      version: 2.1
+      orbs:
+        with-git-deploy-key: ovotech/with-git-deploy-key@1
+      jobs:
+        gitops_image_update:
+          machine: true
+          parameters:
+            image: {type: string}
+          steps:
+          - with-git-deploy-key/do:
+              ssh_key_fingerprint: "00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff"
+              git_steps:
+                - run: git clone git@github.com:myorg/gitops.git gitops
+                - run:
+                    name: "Gitops: update image"
+                    command: |
+                      cd gitops
+                      #
+                      # Update image here, for instance 'kustomize edit set image << parameters.image >>'
+                      #
+                      git commit -m "CircleCI deploy ${CIRCLE_PROJECT_REPONAME}" -m  "Build URL: ${CIRCLE_BUILD_URL}" -a
+                      git push


### PR DESCRIPTION
Sometimes you need to execute git operations on another private repository. When accessing github over SSH, git uses first available key, which is usually the key for your "main" repository, and that key is a [Github deploy key](https://developer.github.com/v3/guides/managing-deploy-keys/). This key is accepted by SSH, so SSH stops trying other keys found in ssh-agent, but rejected by Github auth as not having sufficient permissions for another repository.

This orb provides a command, which configures Git to use specific key found in ssh-agent. Key is  dentified by a fingerprint and needs to be present in the agent already. On a CircleCI you can add more keys to the ssh-agent by creating aditional SSH keys in the project settings.