### PR TITLE
Terraform: search for backend-config and var-file in module path too

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -97,9 +97,9 @@ Parameters:
 - path (string): Path the the terraform module to run the plan in
 - workspace (string): Terraform workspace to run the command in (default: 'default')
 - label (string): An optional friendly name for the environment this plan is for. This must be set if there are multiple plans in a job with the same path and workspace.
-- backend_config_file (string): Comma separated list of terraform backend config files
+- backend_config_file (string): Comma separated list of terraform backend config files. File location is relative to either checkout dir or directory specified in `path`.
 - backend_config (string): Comma separated list of backend configs, e.g. foo=bar
-- var_file (string): Comma separater list of terraform var files
+- var_file (string): Comma separater list of terraform var files. File location is relative to either checkout dir or directory specified in `path`.
 - var (string): Comma separated list of vars to set, e.g. foo=bar
 - parallelism (int): Limit the number of concurrent operations
 - add_github_comment (bool): 'true' to comment on an open PR with the plan. Default: true

--- a/terraform/init.sh
+++ b/terraform/init.sh
@@ -1,7 +1,14 @@
 # Initialize terraform
 if [[ -n "<< parameters.backend_config_file >>" ]]; then
     for file in $(echo "<< parameters.backend_config_file >>" | tr ',' '\n'); do
-        INIT_ARGS="$INIT_ARGS -backend-config=$file"
+        if [[ -f "$file" ]]; then
+            INIT_ARGS="$INIT_ARGS -backend-config=$file"
+        elif [[ -f "$module_path/$file" ]]; then
+            INIT_ARGS="$INIT_ARGS -backend-config=$module_path/$file"
+        else
+            echo "Backend config '$file' wasn't found" >&2
+            exit 1
+        fi
     done
 fi
 

--- a/terraform/set_plan_args.sh
+++ b/terraform/set_plan_args.sh
@@ -10,7 +10,14 @@ fi
 
 if [[ -n "<< parameters.var_file >>" ]]; then
     for file in $(echo "<< parameters.var_file >>" | tr ',' '\n'); do
-        PLAN_ARGS="$PLAN_ARGS -var-file=$file"
+        if [[ -f "$file" ]]; then
+            PLAN_ARGS="$PLAN_ARGS -var-file=$file"
+        elif [[ -f "$module_path/$file" ]]; then
+            PLAN_ARGS="$PLAN_ARGS -var-file=$module_path/$file"
+        else
+            echo "Var file '$file' wasn't found" >&2
+            exit 1
+        fi
     done
 fi
 


### PR DESCRIPTION
Backwards compatible change to search for backend config file relative to module path