### PR TITLE
Set a lock-timeout

### DIFF
--- a/terraform/CHANGELOG.md
+++ b/terraform/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
 not listed.
 
+## ovotech/terraform@1.6.8
+### Changed
+- Terraform commands will now keep trying to obtain the state lock for 5 minutes instead of failing immediately.
+
 ## ovotech/terraform@1.6.7
 ### Changed
 - Updated tfswitch to 0.8.832.

--- a/terraform/apply.sh
+++ b/terraform/apply.sh
@@ -19,7 +19,7 @@ function update_status() {
 
 function apply() {
     set +e
-    terraform apply -input=false -no-color -auto-approve plan.out | $TFMASK
+    terraform apply -input=false -no-color -auto-approve -lock-timeout=300s plan.out | $TFMASK
     local TF_EXIT=${PIPESTATUS[0]}
     set -e
 
@@ -42,7 +42,7 @@ update_status "Applying plan in CircleCI Job [${CIRCLE_JOB}](${CIRCLE_BUILD_URL}
 exec 3>&1
 
 set +e
-terraform plan -input=false -no-color -detailed-exitcode -out=plan.out $PLAN_ARGS "$module_path" \
+terraform plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS "$module_path" \
     | $TFMASK \
     | tee /dev/fd/3 \
     | sed '1,/---/d' \

--- a/terraform/check.sh
+++ b/terraform/check.sh
@@ -1,7 +1,7 @@
 exec 3>&1
 
 set +e
-terraform plan -input=false -no-color -detailed-exitcode $PLAN_ARGS "$module_path" \
+terraform plan -input=false -no-color -detailed-exitcode -lock-timeout=300s $PLAN_ARGS "$module_path" \
     | $TFMASK \
     | tee /dev/fd/3 \
     | sed '1,/---/d' \

--- a/terraform/delete_workspace.sh
+++ b/terraform/delete_workspace.sh
@@ -1,2 +1,2 @@
 terraform workspace select -no-color "default" "$module_path"
-terraform workspace delete -no-color "$workspace" "$module_path"
+terraform workspace delete -no-color -lock-timeout=300s "$workspace" "$module_path"

--- a/terraform/destroy.sh
+++ b/terraform/destroy.sh
@@ -1,1 +1,1 @@
-terraform destroy -input=false -no-color -auto-approve $PLAN_ARGS "$module_path"
+terraform destroy -input=false -no-color -auto-approve -lock-timeout=300s $PLAN_ARGS "$module_path"

--- a/terraform/init.sh
+++ b/terraform/init.sh
@@ -28,4 +28,4 @@ export workspace
 unset TF_WORKSPACE
 
 rm -rf .terraform
-terraform init -input=false -no-color $INIT_ARGS "$module_path"
+terraform init -input=false -lock-timeout=300s -no-color $INIT_ARGS "$module_path"

--- a/terraform/new_workspace.sh
+++ b/terraform/new_workspace.sh
@@ -1,5 +1,5 @@
 if terraform workspace list -no-color "$module_path" | grep "$workspace" >/dev/null; then
   terraform workspace select -no-color "$workspace" "$module_path"
 else
-  terraform workspace new -no-color "$workspace" "$module_path"
+  terraform workspace new -no-color -lock-timeout=300s "$workspace" "$module_path"
 fi

--- a/terraform/orb_version.txt
+++ b/terraform/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform@1.6.7
+ovotech/terraform@1.6.8

--- a/terraform/plan.sh
+++ b/terraform/plan.sh
@@ -5,7 +5,7 @@ EOF
 exec 3>&1
 
 set +e
-terraform plan -input=false -no-color -detailed-exitcode -out=plan.out $PLAN_ARGS "$module_path" \
+terraform plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS "$module_path" \
     | $TFMASK \
     | tee /dev/fd/3 \
     | sed '1,/---/d' \


### PR DESCRIPTION
This will keep retrying to obtain the state lock for 5 minutes before failing.
Current behaviour is to fail immediately, and the only sensible action is to retry it manually.

5 minutes should be long enough that it's quicker than noticing and retrying manually, but not long enough
that builds are stuck if the state lock is stale.

It's not exposed as an option, but it should address the issue seen #113

I've adapted the terraform orb for GitHub actions, and this is one of the changes I made on the way. 
Check it out: https://github.com/dflook/terraform-github-actions