### PR TITLE
Add ovorotatetest tf provider

### DIFF
--- a/terraform/CHANGELOG.md
+++ b/terraform/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
 not listed.
 
+## ovotech/terraform@1.6.8
+### Changed
+- Added ovo-rotate-test provider
+
 ## ovotech/terraform@1.6.7
 ### Changed
 - Updated tfswitch to 0.8.832.

--- a/terraform/executor/Dockerfile-0.11
+++ b/terraform/executor/Dockerfile-0.11
@@ -15,6 +15,7 @@ ARG TF_ACME_VERSIONS="1.0.0 0.6.0 0.5.0 0.4.0 0.3.0"
 ARG TF_AIVEN_VERSIONS="1.0.19 1.0.20 1.1.0 1.1.1 1.1.2 1.1.3 1.1.4"
 ARG TF_OLD_AIVEN_VERSIONS="1.0.0 1.0.1 1.0.2 1.0.3 1.0.4 1.0.5 1.0.6 1.0.7 1.0.8 1.0.9 1.0.10 1.0.11 1.0.12 1.0.13 1.0.15 1.0.16 1.0.17 1.0.18"
 ARG TF_OVO_VERSIONS="1.0.0"
+ARG TF_OVO_ROTATE_TEST_VERSIONS="0.0.1"
 
 # Terraform environment variables
 ENV CHECKPOINT_DISABLE=true
@@ -90,6 +91,13 @@ RUN for TF_ACME_VERSION in $TF_ACME_VERSIONS; do \
 # ovo provider
 RUN for TF_OVO_VERSION in $TF_OVO_VERSIONS; do \
       curl -f -L https://ovo-kafka-user.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
+      && unzip ovo.zip -d /root/.terraform.d/plugins \
+      && rm ovo.zip; \
+    done
+
+# ovorotatetest provider
+RUN for TF_OVO_VERSION in $TF_OVO_VERSIONS; do \
+      curl -f -L https://ovo-kafka-user-tf-provider.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo-rotate-test_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
       && unzip ovo.zip -d /root/.terraform.d/plugins \
       && rm ovo.zip; \
     done

--- a/terraform/executor/Dockerfile-0.11
+++ b/terraform/executor/Dockerfile-0.11
@@ -96,8 +96,8 @@ RUN for TF_OVO_VERSION in $TF_OVO_VERSIONS; do \
     done
 
 # ovorotatetest provider
-RUN for TF_OVO_VERSION in $TF_OVO_VERSIONS; do \
-      curl -f -L https://ovo-kafka-user-tf-provider.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo-rotate-test_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
+RUN for TF_OVO_ROTATE_TEST_VERSION in $TF_OVO_ROTATE_TEST_VERSIONS; do \
+      curl -f -L https://ovo-kafka-user-tf-provider.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_ROTATE_TEST_VERSION}/terraform-provider-ovo-rotate-test_${TF_OVO_ROTATE_TEST_VERSION}_linux_amd64.zip -o ovo.zip \
       && unzip ovo.zip -d /root/.terraform.d/plugins \
       && rm ovo.zip; \
     done

--- a/terraform/executor/Dockerfile-0.12
+++ b/terraform/executor/Dockerfile-0.12
@@ -83,8 +83,8 @@ RUN mkdir -p /root/.terraform.d/plugins \
     done
 
 # ovorotatetest provider
-RUN for TF_OVO_VERSION in $TF_OVO_VERSIONS; do \
-      curl -f -L https://ovo-kafka-user-tf-provider.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo-rotate-test_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
+RUN for TF_OVO_ROTATE_TEST_VERSION in $TF_OVO_ROTATE_TEST_VERSIONS; do \
+      curl -f -L https://ovo-kafka-user-tf-provider.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_ROTATE_TEST_VERSION}/terraform-provider-ovo-rotate-test_${TF_OVO_ROTATE_TEST_VERSION}_linux_amd64.zip -o ovo.zip \
       && unzip ovo.zip -d /root/.terraform.d/plugins \
       && rm ovo.zip; \
     done

--- a/terraform/executor/Dockerfile-0.12
+++ b/terraform/executor/Dockerfile-0.12
@@ -15,6 +15,7 @@ ARG TFSWITCH_VERSION=0.8.832
 ARG TF_AIVEN_VERSIONS="1.0.19 1.0.20 1.1.0 1.1.1 1.1.2 1.1.3 1.1.4"
 ARG TF_OLD_AIVEN_VERSIONS="1.0.0 1.0.1 1.0.2 1.0.3 1.0.4 1.0.5 1.0.6 1.0.7 1.0.8 1.0.9 1.0.10 1.0.11 1.0.12 1.0.13 1.0.15 1.0.16 1.0.17 1.0.18"
 ARG TF_OVO_VERSIONS="1.0.0"
+ARG TF_OVO_ROTATE_TEST_VERSIONS="0.0.1"
 
 # Terraform environment variables
 ENV CHECKPOINT_DISABLE=true
@@ -77,6 +78,13 @@ RUN curl -fsL "https://get.helm.sh/helm-v${HELM3_VERSION}-linux-amd64.tar.gz" | 
 RUN mkdir -p /root/.terraform.d/plugins \
  && for TF_OVO_VERSION in $TF_OVO_VERSIONS; do \
       curl -f -L https://ovo-kafka-user.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
+      && unzip ovo.zip -d /root/.terraform.d/plugins \
+      && rm ovo.zip; \
+    done
+
+# ovorotatetest provider
+RUN for TF_OVO_VERSION in $TF_OVO_VERSIONS; do \
+      curl -f -L https://ovo-kafka-user-tf-provider.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo-rotate-test_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
       && unzip ovo.zip -d /root/.terraform.d/plugins \
       && rm ovo.zip; \
     done

--- a/terraform/orb_version.txt
+++ b/terraform/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform@1.6.7
+ovotech/terraform@1.6.8


### PR DESCRIPTION
This adds the [ovo-rotate-test provider](https://github.com/ovotech/kafka-users-rotate-test/) that teams at OVO will need to use during their testing.