### PR TITLE
Fix helm package url

### DIFF
--- a/terraform/CHANGELOG.md
+++ b/terraform/CHANGELOG.md
@@ -5,6 +5,7 @@ not listed.
 
 ## ovotech/terraform@1.6.8
 ### Changed
+- Updated executors to include helm2 @v2.16.9
 - Terraform commands will now keep trying to obtain the state lock for 5 minutes instead of failing immediately.
 
 ## ovotech/terraform@1.6.7

--- a/terraform/executor/Dockerfile-0.11
+++ b/terraform/executor/Dockerfile-0.11
@@ -8,7 +8,7 @@ FROM debian:buster-slim
 ARG TF_VERSIONS="0.11.12 0.11.13 0.11.14"
 ARG GCLOUD_VERSION=279.0.0
 ARG AWSCLI_VERSION=1.17.11
-ARG HELM_VERSION=2.16.1
+ARG HELM_VERSION=2.16.9
 ARG TFSWITCH_VERSION=0.8.832
 ARG TF_HELM_VERSIONS="0.6.0 0.5.1 0.5.0 0.4.0 0.3.2 0.3.1 0.3.0 0.2.0 0.1.0"
 ARG TF_ACME_VERSIONS="1.0.0 0.6.0 0.5.0 0.4.0 0.3.0"
@@ -66,7 +66,7 @@ RUN mkdir -p /root/aiven \
       && chmod +x /root/aiven/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
     done
 
-RUN curl -fsL "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz" | tar -xzvf- \
+RUN curl -fsL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" | tar -xzvf- \
  && mv linux-amd64/helm /usr/local/bin/helm \
  && rm -rf helm*.tar.gz linux-amd64/ \
  && helm init --client-only

--- a/terraform/executor/Dockerfile-0.12
+++ b/terraform/executor/Dockerfile-0.12
@@ -9,7 +9,7 @@ ARG TF_VERSIONS="0.12.0 0.12.1 0.12.2 0.12.3 0.12.4 0.12.5 0.12.6 0.12.7 0.12.8 
 ARG DEFAULT_TF_VERSION=0.12.5
 ARG GCLOUD_VERSION=279.0.0
 ARG AWSCLI_VERSION=1.17.11
-ARG HELM2_VERSION=2.16.1
+ARG HELM2_VERSION=2.16.9
 ARG HELM3_VERSION=3.0.3
 ARG TFSWITCH_VERSION=0.8.832
 ARG TF_AIVEN_VERSIONS="1.0.19 1.0.20 1.1.0 1.1.1 1.1.2 1.1.3 1.1.4"
@@ -61,7 +61,7 @@ RUN mkdir -p /root/.terraform.d/plugins \
     done
 
 # helm 2
-RUN curl -fsL "https://storage.googleapis.com/kubernetes-helm/helm-v${HELM2_VERSION}-linux-amd64.tar.gz" | tar -xzvf- \
+RUN curl -fsL "https://get.helm.sh/helm-v${HELM2_VERSION}-linux-amd64.tar.gz" | tar -xzvf- \
  && mv linux-amd64/helm /usr/local/bin/helm2 \
  && rm -rf helm*.tar.gz linux-amd64/ \
  && ln -s /usr/local/bin/helm2 /usr/local/bin/helm \


### PR DESCRIPTION
Helm 2.16.1 install package has disappeared from its published location.
Newer versions are published somewhere else, so helm has been upgraded to 2.16.9 so we can use the new location.