### PR TITLE
Update version with working image

### DIFF
--- a/versioned-lambda/orb.yml
+++ b/versioned-lambda/orb.yml
@@ -8,7 +8,7 @@ orbs:
 executors:
   lambci-node12:
     docker:
-      - image: lambci/lambda:20200721-nodejs12.x
+      - image: lambci/lambda:20200721-build-nodejs12.x
 
 jobs:
   node-test-and-package:

--- a/versioned-lambda/orb.yml
+++ b/versioned-lambda/orb.yml
@@ -8,7 +8,7 @@ orbs:
 executors:
   lambci-node12:
     docker:
-      - image: lambci/lambda:build-nodejs12.x
+      - image: lambci/lambda@sha256:c4cb47ad928cb03d149c424af779294f6638bc1ad232ecb9c3d9cdba857fb484
 
 jobs:
   node-test-and-package:

--- a/versioned-lambda/orb.yml
+++ b/versioned-lambda/orb.yml
@@ -8,7 +8,7 @@ orbs:
 executors:
   lambci-node12:
     docker:
-      - image: lambci/lambda@sha256:c4cb47ad928cb03d149c424af779294f6638bc1ad232ecb9c3d9cdba857fb484
+      - image: lambci/lambda:20200721-nodejs12.x
 
 jobs:
   node-test-and-package:


### PR DESCRIPTION
Small fix to the node12.x lambda version we are using to prevent build-stopping errors in CI.