### PR TITLE
ovotech/terraform@1.6.10

### DIFF
--- a/terraform/CHANGELOG.md
+++ b/terraform/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
 not listed.
 
+## ovotech/terraform@1.6.10
+### Changed
+- No changes to Orb, latest tfmask to be cloned, built and added to Docker image at build time.
+
 ## ovotech/terraform@1.6.9
 ### Changed
 - Updated Terraform to the latest version 0.12.29

--- a/terraform/orb_version.txt
+++ b/terraform/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform@1.6.9
+ovotech/terraform@1.6.10


### PR DESCRIPTION
From looking at the CircleCI config, perhaps incrementing the orb version isn't necessary....we just need a new docker image to be built which has the latest `tfmask`