### PR TITLE
Add npm authentication & shipit to versioned-lambda

### DIFF
--- a/versioned-lambda/README.md
+++ b/versioned-lambda/README.md
@@ -108,6 +108,7 @@ workflows:
           name: deploy-uat
           build-bucket: my-build-bucket
           lambda-function-name: cool-lambda-uat
+          context: my-uat-context
           requires:
             - test-and-package
 
@@ -124,6 +125,7 @@ workflows:
           name: deploy-prod
           build-bucket: my-build-bucket
           lambda-function-name: cool-lambda-prod
+          context: my-prod-context
           notify-shipit: true
           filters:
             branches:

--- a/versioned-lambda/README.md
+++ b/versioned-lambda/README.md
@@ -46,13 +46,14 @@ resource "aws_lambda_function" "cool-lambda" {
 
 **Parameters**
 
-- `executor` - Name of the executor to use for this job. Defaults to the `lambci/lambda:build-nodejs12.x`
-  docker image.
+- `executor` - Name of the executor to use for this job. Defaults a Node `12.x` image.
 - `lambda-zipfile` - Name of the lambda zip file to be built. Defaults to `lambda.zip`.
 - `build-bucket` - Name of the S3 bucket into which the built zip will be uploaded.
-- `vulnerability-audit` - Whether or not to run `npm audit` to check vulnerabilities. Defaults to `true`.
+- `vulnerability-audit` - Whether or not to run `snyk` to check vulnerabilities. Defaults to `true`.
   When run, the build will fail if any dependency vulnerabilities are reported with a severity greater than
-  or equal to "moderate".
+  or equal to "moderate". Requires the `SNYK_TOKEN` environment variable.
+- `authenticate-npm` - Whether or not to authenticate access to the NPM registry. Defaults to `true`. Requires the
+  `NPM_TOKEN` environment variable.
 
 ### create-lambda-version
 
@@ -68,6 +69,10 @@ in the `build-test-and-package` job, i.e. using the repo name, branch and SHA.
 - `lambda-zipfile` - Name of the built lambda zip file. Defaults to `lambda.zip`.
 - `build-bucket` - Name of the S3 bucket containing the built zip will be uploaded.
 - `lambda-function-name` - Name of the Lambda function.
+- `notify-shipit` - Whether or not to notify the `shipit` deployment service. Defaults to `false`.
+  This should be set to `true` only when calling this job for a production deployment. Requires the
+  `SHIPIT_API_KEY` and `TEAM_NAME` environment variables. Uses the
+  [shipit orb](https://github.com/ovotech/pe-orbs/tree/master/shipit) with all default settings.
 
 ## Example
 
@@ -87,25 +92,39 @@ workflows:
   build-test-deploy:
     jobs:
       - versioned-lambda/node-test-and-package:
-          name: test-and-package
+          name: build-uat
           build-bucket: my-build-bucket
+          context: my-uat-context
+
+      - versioned-lambda/node-test-and-package:
+          name: build-prod
+          build-bucket: my-build-bucket
+          context: my-prod-context
+          filters:
+            branches:
+              only: master
+
       - versioned-lambda/create-lambda-version:
-          name: create-lambda-uat
+          name: deploy-uat
           build-bucket: my-build-bucket
           lambda-function-name: cool-lambda-uat
           requires:
             - test-and-package
+
       - hold:
+          type: approval
           filters:
             branches:
               only: master
-          type: approval
           requires:
-            - create-lambda-uat
+            - deploy-uat
+            - build-prod
+
       - versioned-lambda/create-lambda-version:
-          name: create-lambda-prod
+          name: deploy-prod
           build-bucket: my-build-bucket
           lambda-function-name: cool-lambda-prod
+          notify-shipit: true
           filters:
             branches:
               only: master

--- a/versioned-lambda/orb.yml
+++ b/versioned-lambda/orb.yml
@@ -4,6 +4,7 @@ description: An orb to build and deploy AWS Lambda functions written in node.js 
 orbs:
   aws-cli: circleci/aws-cli@1.2.0
   snyk: snyk/snyk@0.0.10
+  shipit: ovotech/shipit@1
 
 executors:
   lambci-node12:
@@ -95,6 +96,10 @@ jobs:
       lambda-function-name:
         description: Name of the lambda function
         type: string
+      notify-shipit:
+        description: Whether or not to notify shipit
+        type: boolean
+        default: false
     executor: aws-cli/default
     steps:
       - aws-cli/setup
@@ -124,3 +129,7 @@ jobs:
               --name $ALIAS \
               --function-version $VERSION \
               --description "The latest build in the $CIRCLE_BRANCH branch"
+      - when:
+          condition: << parameters.notify-shipit >>
+          steps:
+            - shipit/shipit

--- a/versioned-lambda/orb.yml
+++ b/versioned-lambda/orb.yml
@@ -28,9 +28,19 @@ jobs:
         description: "Whether or not to run the Snyk Scan step. Defaults to true"
         type: boolean
         default: true
+      authenticate-npm:
+        description: "Whether or not to authenticate with the npm registry service. Defaults to true"
+        type: boolean
+        default: true
     executor: << parameters.executor >>
     steps:
       - checkout
+      - when:
+          condition: << parameters.authenticate-npm >>
+          steps:
+            - run:
+                name: Authenticate with npm registry
+                command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ./.npmrc
       - restore_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:


### PR DESCRIPTION
NPM Auth:
* Adds optional step to `node-test-and-package` to authenticate with npm if a token is provided in the environment variables.
* Defaults to `true` because we assume that most projects that would use this orb would be using ovotech repositories.

Shipit:
* Adds `notify-shipit` optional step to `create-lambda-version`
* defaults to `false`

Readme updated to reflect new options.