### PR TITLE
Add descriptions to OOT orbs.

### DIFF
--- a/clojure/orb.yml
+++ b/clojure/orb.yml
@@ -1,4 +1,5 @@
 version: 2.1
+description: "Commands for working with Clojure projects."
 
 orbs:
   snyk: snyk/snyk@0.0.10

--- a/clojure/orb_version.txt
+++ b/clojure/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/clojure@0.1.0
+ovotech/clojure@1.0.1

--- a/oot-eks/orb.yml
+++ b/oot-eks/orb.yml
@@ -1,4 +1,5 @@
 version: 2.1
+description: "Opinionated commands for releasing projects on AWS EKS."
 
 orbs:
   aws-cli: circleci/aws-cli@1.2.1

--- a/oot-eks/orb_version.txt
+++ b/oot-eks/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/oot-eks@0.1.0
+ovotech/oot-eks@1.0.1


### PR DESCRIPTION
Note also that the versions have been bumped to `1.0.1` - this is because the initial publish seemed to force a version of `1.0.0` over the `0.1.0` specified in the `orb_version.txt`.