### PR TITLE
Snyk monitor only on master branch

### DIFF
--- a/versioned-lambda/orb.yml
+++ b/versioned-lambda/orb.yml
@@ -61,7 +61,7 @@ jobs:
                 command: yum install -y sudo
             - when:
                 condition:
-                  equal: [master, << pipeline.git.branch >>]
+                  equal: [master, $CIRCLE_BRANCH]
                 steps:
                   snyk/scan:
                     token-variable: SNYK_TOKEN
@@ -70,7 +70,7 @@ jobs:
                     project: ${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}
             - unless:
                 condition:
-                  equal: [master, << pipeline.git.branch >>]
+                  equal: [master, $CIRCLE_BRANCH]
                 steps:
                   snyk/scan:
                     token-variable: SNYK_TOKEN

--- a/versioned-lambda/orb.yml
+++ b/versioned-lambda/orb.yml
@@ -59,11 +59,24 @@ jobs:
             - run:
                 name: Sudo install
                 command: yum install -y sudo
-            - snyk/scan:
-                token-variable: SNYK_TOKEN
-                monitor-on-build: true
-                severity-threshold: low
-                project: ${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}
+            - when:
+                condition:
+                  equal: [master, << pipeline.git.branch >>]
+                steps:
+                  snyk/scan:
+                    token-variable: SNYK_TOKEN
+                    monitor-on-build: true
+                    severity-threshold: low
+                    project: ${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}
+            - unless:
+                condition:
+                  equal: [master, << pipeline.git.branch >>]
+                steps:
+                  snyk/scan:
+                    token-variable: SNYK_TOKEN
+                    monitor-on-build: false
+                    severity-threshold: low
+                    project: ${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}
       - run:
           name: Lint
           command: npm run lint


### PR DESCRIPTION
Monitors when `CIRCLE_BRANCH` is equal to `master`.

This prevents us getting alerted for vulnerabilities in old/duplicate/non-existant branches. Only the most recent snapshot will be monitored.