### PR TITLE
upgrade aiven provider version for slim

### DIFF
--- a/terraform/CHANGELOG.md
+++ b/terraform/CHANGELOG.md
@@ -3,6 +3,19 @@ All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
 not listed.
 
+## ovotech/terraform@1.7.2
+### Changed
+- Updated 0.12 slim executor with Aiven's terraform-provider-aiven 2.0.1 
+
+## ovotech/terraform@1.7.1
+### Changed
+- Added slim Terraform 0.12 executor 
+  This image contains one version of each provider/tool
+
+## ovotech/terraform@1.7.0
+### Changed
+- Added Terraform 0.13 executor
+
 ## ovotech/terraform@1.6.10
 ### Changed
 - No changes to Orb, latest tfmask to be cloned, built and added to Docker image at build time.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -36,7 +36,42 @@ If the AIVEN_PROVIDER environment variable is set, also has:
 
 [Dockerfile](executor/Dockerfile-0.12)
 
-This executor uses terraform 0.12.5 by default. However `tfswitch` is
+This executor uses terraform 0.12.29 by default. However `tfswitch` is
+installed to allow you to adjust at runtime.
+See [Specifying a terraform version](https://github.com/ovotech/circleci-orbs/tree/master/terraform#specifying-a-terraform-version)
+to change this.
+
+It also contains:
+- Aiven's terraform-provider-aiven
+- google-cloud-sdk
+- Helm 2 available as `helm2` and `helm`
+- Helm 3+ available as `helm3` See [Using Helm 3](https://github.com/ovotech/circleci-orbs/tree/master/terraform#Using-Helm-3)
+- aws-cli
+- ovo's kafka user provider
+
+### terraform-0_12-slim
+
+[Dockerfile](executor/Dockerfile-0.12-slim)
+
+A much much slimmer image. Carries one version of each provider/tool.
+This executor uses terraform 0.12.29 by default. However `tfswitch` is
+installed to allow you to adjust at runtime.
+See [Specifying a terraform version](https://github.com/ovotech/circleci-orbs/tree/master/terraform#specifying-a-terraform-version)
+to change this.
+
+It also contains:
+- Aiven's terraform-provider-aiven
+- google-cloud-sdk
+- Helm 2 available as `helm2` and `helm`
+- Helm 3+ available as `helm3` See [Using Helm 3](https://github.com/ovotech/circleci-orbs/tree/master/terraform#Using-Helm-3)
+- aws-cli
+- ovo's kafka user provider
+
+### terraform-0_13
+
+[Dockerfile](executor/Dockerfile-0.13)
+
+This executor uses terraform 0.13.0 by default. However `tfswitch` is
 installed to allow you to adjust at runtime.
 See [Specifying a terraform version](https://github.com/ovotech/circleci-orbs/tree/master/terraform#specifying-a-terraform-version)
 to change this.

--- a/terraform/executor/Dockerfile-0.12-slim
+++ b/terraform/executor/Dockerfile-0.12-slim
@@ -12,7 +12,7 @@ ARG AWSCLI_VERSION=1.17.11
 ARG HELM2_VERSION=2.16.9
 ARG HELM3_VERSION=3.0.3
 ARG TFSWITCH_VERSION=0.8.832
-ARG TF_AIVEN_VERSIONS="1.1.4"
+ARG TF_AIVEN_VERSIONS="2.0.1"
 ARG TF_OVO_VERSIONS="1.0.0"
 
 # Terraform environment variables
@@ -48,9 +48,10 @@ RUN mkdir -p $TF_PLUGIN_CACHE_DIR
 
 RUN mkdir -p /root/.terraform.d/plugins \
  && for TF_AIVEN_VERSION in $TF_AIVEN_VERSIONS; do \
-      curl -f -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven-linux-amd64_v${TF_AIVEN_VERSION}" \
-        -o /root/.terraform.d/plugins/terraform-provider-aiven_v${TF_AIVEN_VERSION} \
-      && chmod +x /root/.terraform.d/plugins/terraform-provider-aiven_v${TF_AIVEN_VERSION}; \
+      curl -f -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven_{TF_AIVEN_VERSION}_linux_amd64.zip" -o aiven-provider.zip \
+      && unzip aiven-provider.zip terraform-provider-aiven_v{TF_AIVEN_VERSION} -d /root/.terraform.d/plugins \
+      && chmod +x /root/.terraform.d/plugins/terraform-provider-aiven_v${TF_AIVEN_VERSION}
+      && rm aiven-provider.zip; \
     done
 
 # helm 2

--- a/terraform/executor/Dockerfile-0.12-slim
+++ b/terraform/executor/Dockerfile-0.12-slim
@@ -50,7 +50,7 @@ RUN mkdir -p /root/.terraform.d/plugins \
  && for TF_AIVEN_VERSION in $TF_AIVEN_VERSIONS; do \
       curl -f -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven_{TF_AIVEN_VERSION}_linux_amd64.zip" -o aiven-provider.zip \
       && unzip aiven-provider.zip terraform-provider-aiven_v{TF_AIVEN_VERSION} -d /root/.terraform.d/plugins \
-      && chmod +x /root/.terraform.d/plugins/terraform-provider-aiven_v${TF_AIVEN_VERSION}
+      && chmod +x /root/.terraform.d/plugins/terraform-provider-aiven_v${TF_AIVEN_VERSION} \
       && rm aiven-provider.zip; \
     done
 

--- a/terraform/executor/Dockerfile-0.12-slim
+++ b/terraform/executor/Dockerfile-0.12-slim
@@ -48,8 +48,8 @@ RUN mkdir -p $TF_PLUGIN_CACHE_DIR
 
 RUN mkdir -p /root/.terraform.d/plugins \
  && for TF_AIVEN_VERSION in $TF_AIVEN_VERSIONS; do \
-      curl -f -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven_{TF_AIVEN_VERSION}_linux_amd64.zip" -o aiven-provider.zip \
-      && unzip aiven-provider.zip terraform-provider-aiven_v{TF_AIVEN_VERSION} -d /root/.terraform.d/plugins \
+      curl -f -L "https://github.com/aiven/terraform-provider-aiven/releases/download/v${TF_AIVEN_VERSION}/terraform-provider-aiven_${TF_AIVEN_VERSION}_linux_amd64.zip" -o aiven-provider.zip \
+      && unzip aiven-provider.zip terraform-provider-aiven_v${TF_AIVEN_VERSION} -d /root/.terraform.d/plugins \
       && chmod +x /root/.terraform.d/plugins/terraform-provider-aiven_v${TF_AIVEN_VERSION} \
       && rm aiven-provider.zip; \
     done

--- a/terraform/orb_version.txt
+++ b/terraform/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform@1.7.1
+ovotech/terraform@1.7.2


### PR DESCRIPTION
I understand the slim executor should have the latest version.
Aiven worked out the ACL username validation issues and we tested
that locally just running tf plan for the kafka-uat config in
aiven as code.
Aiven have also changed the structure of the filenames of their
release assets. Made some changes to executor to accommodate

After this I'll look at changing the executor for the uat jobs in aiven as
code over to using the slim executor. Not going ahead and updating 
the executor all the aac jobs use is just out of caution around 
the ACL username validation issue in particular and the fact that we’ve
not updated the version we’re using since February so there is some 
risk from the unexpected. There is a major version bump too. 