### PR TITLE
Clojure orb: Ensure that all maven dependencies are pulled down before running snyk scan

### DIFF
--- a/clojure/orb.yml
+++ b/clojure/orb.yml
@@ -59,6 +59,10 @@ commands:
             - v1-dependencies-
 
       - run:
+          name: Ensure dependencies are present
+          command: lein deps
+
+      - run:
           name: Generate pom.xml for Snyk
           command: lein pom
 

--- a/clojure/orb_version.txt
+++ b/clojure/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/clojure@1.0.1
+ovotech/clojure@1.0.2


### PR DESCRIPTION
...as there seems to be an occasional race condition between scanning and running the test job.