### PR TITLE
Add tf-provider aiven-kafka-users

### DIFF
--- a/rac-gcp-deploy/executor/Dockerfile
+++ b/rac-gcp-deploy/executor/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add --update --no-cache curl ca-certificates \
 RUN set -x \
   && apk --update add --no-cache --virtual .build-deps curl \
   && ESUM="9bb9212541176d6fcce7bd12e4cf8a9c9649f5b63f88b3aff474e0b02c7cfe58" \
-  && SBT_URL="https://piccolo.link/sbt-${SBT_VERSION}.tgz" \
+  && SBT_URL="https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz" \
   && apk add shadow \
   && apk add bash \
   && apk add openssh \

--- a/terraform/CHANGELOG.md
+++ b/terraform/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
 not listed.
 
+## ovotech/terraform@1.7.5
+## Changed
+- Added terraform-provider-aiven-kafka-users v0.0.1
+
+## ovotech/terraform@1.7.4
+## Changed
+- Add new TF 0.13.x vers and Aiven providers
+
 ## ovotech/terraform@1.7.3
 ## Changed
 - Updated `helm`, `helm2` and `awscli` packages for 0.12, 0.12-slim and 0.13 executors

--- a/terraform/executor/Dockerfile-0.11
+++ b/terraform/executor/Dockerfile-0.11
@@ -15,6 +15,7 @@ ARG TF_ACME_VERSIONS="1.0.0 0.6.0 0.5.0 0.4.0 0.3.0"
 ARG TF_AIVEN_VERSIONS="1.0.19 1.0.20 1.1.0 1.1.1 1.1.2 1.1.3 1.1.4"
 ARG TF_OLD_AIVEN_VERSIONS="1.0.0 1.0.1 1.0.2 1.0.3 1.0.4 1.0.5 1.0.6 1.0.7 1.0.8 1.0.9 1.0.10 1.0.11 1.0.12 1.0.13 1.0.15 1.0.16 1.0.17 1.0.18"
 ARG TF_OVO_VERSIONS="1.0.0"
+ARG TF_AIVEN_KAFKA_USERS_VERSIONS="0.0.1"
 
 # Terraform environment variables
 ENV CHECKPOINT_DISABLE=true
@@ -92,6 +93,13 @@ RUN for TF_OVO_VERSION in $TF_OVO_VERSIONS; do \
       curl -f -L https://ovo-kafka-user.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
       && unzip ovo.zip -d /root/.terraform.d/plugins \
       && rm ovo.zip; \
+    done
+
+# aiven_kafka_users provider
+RUN for TF_AIVEN_KAFKA_USERS_VERSION in $TF_AIVEN_KAFKA_USERS_VERSIONS; do \
+      curl -f -L https://kafka-users-prod-tf-provider.s3-eu-west-1.amazonaws.com/terraform-provider-aiven-kafka-users/${TF_AIVEN_KAFKA_USERS_VERSION}/terraform-provider-aiven-kafka-users_${TF_AIVEN_KAFKA_USERS_VERSION}_linux_amd64.zip -o aiven-kafka-users.zip \
+      && unzip aiven-kafka-users.zip -d /root/.terraform.d/plugins \
+      && rm aiven-kafka-users.zip; \
     done
 
 RUN curl -fsL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_VERSION}-linux-x86_64.tar.gz -o /opt/google-cloud-sdk.tar.gz \

--- a/terraform/executor/Dockerfile-0.12
+++ b/terraform/executor/Dockerfile-0.12
@@ -16,6 +16,7 @@ ARG NEW_TF_AIVEN_VERSIONS="2.0.1 2.0.5 2.0.6"
 ARG TF_AIVEN_VERSIONS="1.0.19 1.0.20 1.1.0 1.1.1 1.1.2 1.1.3 1.1.4 1.3.5"
 ARG TF_OLD_AIVEN_VERSIONS="1.0.0 1.0.1 1.0.2 1.0.3 1.0.4 1.0.5 1.0.6 1.0.7 1.0.8 1.0.9 1.0.10 1.0.11 1.0.12 1.0.13 1.0.15 1.0.16 1.0.17 1.0.18"
 ARG TF_OVO_VERSIONS="1.0.0"
+ARG TF_AIVEN_KAFKA_USERS_VERSIONS="0.0.1"
 
 # Terraform environment variables
 ENV CHECKPOINT_DISABLE=true
@@ -87,6 +88,13 @@ RUN mkdir -p /root/.terraform.d/plugins \
       curl -f -L https://ovo-kafka-user.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
       && unzip ovo.zip -d /root/.terraform.d/plugins \
       && rm ovo.zip; \
+    done
+
+# aiven_kafka_users provider
+RUN for TF_AIVEN_KAFKA_USERS_VERSION in $TF_AIVEN_KAFKA_USERS_VERSIONS; do \
+      curl -f -L https://kafka-users-prod-tf-provider.s3-eu-west-1.amazonaws.com/terraform-provider-aiven-kafka-users/${TF_AIVEN_KAFKA_USERS_VERSION}/terraform-provider-aiven-kafka-users_${TF_AIVEN_KAFKA_USERS_VERSION}_linux_amd64.zip -o aiven-kafka-users.zip \
+      && unzip aiven-kafka-users.zip -d /root/.terraform.d/plugins \
+      && rm aiven-kafka-users.zip; \
     done
 
 RUN curl -fsL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_VERSION}-linux-x86_64.tar.gz -o /opt/google-cloud-sdk.tar.gz \

--- a/terraform/executor/Dockerfile-0.12-slim
+++ b/terraform/executor/Dockerfile-0.12-slim
@@ -14,6 +14,7 @@ ARG HELM3_VERSION=3.3.1
 ARG TFSWITCH_VERSION=0.8.832
 ARG TF_AIVEN_VERSIONS="2.0.6"
 ARG TF_OVO_VERSIONS="1.0.0"
+ARG TF_AIVEN_KAFKA_USERS_VERSIONS="0.0.1"
 
 # Terraform environment variables
 ENV CHECKPOINT_DISABLE=true
@@ -73,6 +74,13 @@ RUN mkdir -p /root/.terraform.d/plugins \
       curl -f -L https://ovo-kafka-user.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
       && unzip ovo.zip -d /root/.terraform.d/plugins \
       && rm ovo.zip; \
+    done
+
+# aiven_kafka_users provider
+RUN for TF_AIVEN_KAFKA_USERS_VERSION in $TF_AIVEN_KAFKA_USERS_VERSIONS; do \
+      curl -f -L https://kafka-users-prod-tf-provider.s3-eu-west-1.amazonaws.com/terraform-provider-aiven-kafka-users/${TF_AIVEN_KAFKA_USERS_VERSION}/terraform-provider-aiven-kafka-users_${TF_AIVEN_KAFKA_USERS_VERSION}_linux_amd64.zip -o aiven-kafka-users.zip \
+      && unzip aiven-kafka-users.zip -d /root/.terraform.d/plugins \
+      && rm aiven-kafka-users.zip; \
     done
 
 RUN curl -fsL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_VERSION}-linux-x86_64.tar.gz -o /opt/google-cloud-sdk.tar.gz \

--- a/terraform/executor/Dockerfile-0.13
+++ b/terraform/executor/Dockerfile-0.13
@@ -17,6 +17,7 @@ ARG TFSWITCH_VERSION=0.8.832
 # to automatically install the correct v2.x Aiven provider
 ARG TF_AIVEN_VERSIONS="1.3.5"
 ARG TF_OVO_VERSIONS="1.0.0"
+ARG TF_AIVEN_KAFKA_USERS_VERSIONS="0.0.1"
 
 # Terraform environment variables
 ENV CHECKPOINT_DISABLE=true
@@ -76,6 +77,13 @@ RUN mkdir -p /root/.terraform.d/plugins \
       curl -f -L https://ovo-kafka-user.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
       && unzip ovo.zip -d /root/.terraform.d/plugins \
       && rm ovo.zip; \
+    done
+
+# aiven_kafka_users provider
+RUN for TF_AIVEN_KAFKA_USERS_VERSION in $TF_AIVEN_KAFKA_USERS_VERSIONS; do \
+      curl -f -L https://kafka-users-prod-tf-provider.s3-eu-west-1.amazonaws.com/terraform-provider-aiven-kafka-users/${TF_AIVEN_KAFKA_USERS_VERSION}/terraform-provider-aiven-kafka-users_${TF_AIVEN_KAFKA_USERS_VERSION}_linux_amd64.zip -o aiven-kafka-users.zip \
+      && unzip aiven-kafka-users.zip -d /root/.terraform.d/plugins \
+      && rm aiven-kafka-users.zip; \
     done
 
 RUN curl -fsL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_VERSION}-linux-x86_64.tar.gz -o /opt/google-cloud-sdk.tar.gz \

--- a/terraform/orb_version.txt
+++ b/terraform/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform@1.7.4
+ovotech/terraform@1.7.5


### PR DESCRIPTION
This adds the new `terraform-provider-aiven-kafka-users` (which has cred rotation cababilities) to the terraform orb.