### PR TITLE
Fix invalid version on ssh-proxy orb

### DIFF
--- a/ssh-proxy/orb_version.txt
+++ b/ssh-proxy/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/ssh-proxy@0.1
+ovotech/ssh-proxy@1.0.0


### PR DESCRIPTION
CircleCI requires orbs to be versioned on `x.y.z` format. This PR fixes the version I attached in the repository.