### PR TITLE
Revert HCL highlighting

### DIFF
--- a/terraform/CHANGELOG.md
+++ b/terraform/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
-not listed.
+not listed
+
+## ovotech/terraform@1.7.7
+## Changed
+- Revert HCL syntax highlighting
 
 ## ovotech/terraform@1.7.6
 ## Changed

--- a/terraform/github.py
+++ b/terraform/github.py
@@ -144,7 +144,7 @@ class TerraformComment:
         self._update_comment()
 
     def _update_comment(self):
-        comment = f'{self._comment_identifier}\n```hcl\n{self.plan}\n```'
+        comment = f'{self._comment_identifier}\n```\n{self.plan}\n```'
 
         if self.status:
             comment += '\n' + self.status

--- a/terraform/github.py
+++ b/terraform/github.py
@@ -69,8 +69,7 @@ class TerraformComment:
         self._comment_url = None
         for comment in response.json():
             if comment['user']['login'] == github_username:
-                match = re.match(rf'{re.escape(self._comment_identifier)}\n```(?:hcl)(.*?)```(.*)', comment['body'], re.DOTALL)
-
+                match = re.match(rf'{re.escape(self._comment_identifier)}\n```(.*?)```(.*)', comment['body'], re.DOTALL)
                 if match:
                     self._comment_url = comment['url']
                     self._plan = match.group(1).strip()

--- a/terraform/orb_version.txt
+++ b/terraform/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform@1.7.6
+ovotech/terraform@1.7.7


### PR DESCRIPTION
Reverts the changes made in #158, I saw a failed job when using the new orb version with comments on a PR from an old version. I've still not tracked any specific errors down, but safer to revert for now I think..