### PR TITLE
Add hcl formatting

### DIFF
--- a/terraform/CHANGELOG.md
+++ b/terraform/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
 not listed
 
+## ovotech/terraform@1.7.8
+## Changed
+- Added HCL syntax highlighting
+
 ## ovotech/terraform@1.7.7
 ## Changed
 - Revert HCL syntax highlighting

--- a/terraform/apply.sh
+++ b/terraform/apply.sh
@@ -6,6 +6,10 @@ cat >/tmp/cmp.py <<"EOF"
 include cmp.py
 EOF
 
+cat >/tmp/comment_util.py <<"EOF"
+include comment_util.py
+EOF
+
 export CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"
 export label="<< parameters.label >>"
 

--- a/terraform/comment_util.py
+++ b/terraform/comment_util.py
@@ -1,0 +1,12 @@
+import re
+
+
+def re_comment_match(comment_id, comment_body):
+    """Returns a Match object, or None if no match was found"""
+    return re.match(rf'{re.escape(comment_id)}\n```(?:hcl)?(.*?)```(.*)',
+                    comment_body, re.DOTALL)
+
+
+def comment_for_pr(comment_id, plan):
+    """Returns a formatted string containing comment_id and plan"""
+    return f'{comment_id}\n```hcl\n{plan}\n```'

--- a/terraform/github.py
+++ b/terraform/github.py
@@ -69,7 +69,6 @@ class TerraformComment:
         self._comment_url = None
         for comment in response.json():
             if comment['user']['login'] == github_username:
-                # match = re.match(rf'{re.escape(self._comment_identifier)}\n```(?:hcl)?(.*?)```(.*)', comment['body'], re.DOTALL)
                 match = comment_util.re_comment_match(self.comment_identifier,
                                                       comment['body'])
                 if match:

--- a/terraform/github.py
+++ b/terraform/github.py
@@ -69,7 +69,7 @@ class TerraformComment:
         self._comment_url = None
         for comment in response.json():
             if comment['user']['login'] == github_username:
-                match = comment_util.re_comment_match(self.comment_identifier,
+                match = comment_util.re_comment_match(self._comment_identifier,
                                                       comment['body'])
                 if match:
                     self._comment_url = comment['url']

--- a/terraform/github.py
+++ b/terraform/github.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import os
-import re
+import comment_util
 import sys
 from typing import Optional, Dict, Iterable
 
@@ -69,7 +69,9 @@ class TerraformComment:
         self._comment_url = None
         for comment in response.json():
             if comment['user']['login'] == github_username:
-                match = re.match(rf'{re.escape(self._comment_identifier)}\n```(.*?)```(.*)', comment['body'], re.DOTALL)
+                # match = re.match(rf'{re.escape(self._comment_identifier)}\n```(?:hcl)?(.*?)```(.*)', comment['body'], re.DOTALL)
+                match = comment_util.re_comment_match(self.comment_identifier,
+                                                      comment['body'])
                 if match:
                     self._comment_url = comment['url']
                     self._plan = match.group(1).strip()
@@ -144,7 +146,8 @@ class TerraformComment:
         self._update_comment()
 
     def _update_comment(self):
-        comment = f'{self._comment_identifier}\n```\n{self.plan}\n```'
+        comment = comment_util.comment_for_pr(self._comment_identifier,
+                                              self.plan)
 
         if self.status:
             comment += '\n' + self.status

--- a/terraform/orb_version.txt
+++ b/terraform/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform@1.7.7
+ovotech/terraform@1.7.8

--- a/terraform/plan.sh
+++ b/terraform/plan.sh
@@ -2,6 +2,10 @@ cat >/tmp/github.py <<"EOF"
 include github.py
 EOF
 
+cat >/tmp/comment_util.py <<"EOF"
+include comment_util.py
+EOF
+
 exec 3>&1
 
 set +e

--- a/terraform/test_comment_util.py
+++ b/terraform/test_comment_util.py
@@ -1,0 +1,29 @@
+import comment_util
+import pytest
+
+
+@pytest.mark.parametrize("comment_id,comment_body,match_group_one,match_group_two",
+                         [
+                            #  pre addition of HCL syntax formatting
+                             ("<comment_id>",
+                              "<comment_id>\n```\n<plan>\n```<status>",
+                              "<plan>",
+                              "<status>"
+                             ),
+                            #  post addition of HCL syntax formatting
+                             ("<comment_id>",
+                              "<comment_id>\n```hcl\n<plan>\n```<status>",
+                              "<plan>",
+                              "<status>"
+                             ),
+                          ])
+def test_regex_comment_match(comment_id, comment_body, 
+                             match_group_one, match_group_two):
+    match = comment_util.re_comment_match(comment_id, comment_body)
+    assert match.group(1).strip() == match_group_one
+    assert match.group(2).strip() == match_group_two
+
+
+def test_comment_for_pr():
+    comment_for_pr = comment_util.comment_for_pr("<comment_id>", "<plan>")
+    assert comment_for_pr == "<comment_id>\n```hcl\n<plan>\n```"


### PR DESCRIPTION
- created `terraform/comment_util.py` with functions for regex matching and creation of the comment that's put onto PRs, and updated `terraform/github.py` to use new functions
- created `terraform/test_comment_util.py` with some tests in
- updated the `terraform/plan.sh` and `terraform/apply.sh` to copy new util python file to `/tmp`

I tested the devorb, and both plan and apply were successful (with HCL highlighting).

I haven't been able to test the case of a plan being done on old version, and apply being done on new version, but I think my unit tests cover that.

Credit to @gordonkeogh for the initial work on this; this PR is just to fix the changes on #158 