### PR TITLE
Set AWS_REGION in kubernetes yaml for oot services

### DIFF
--- a/oot-eks/orb.yml
+++ b/oot-eks/orb.yml
@@ -107,6 +107,7 @@ commands:
       - run:
           command: |
             sed -i "s/{{AWS_ACCOUNT_ID}}/<< parameters.account >>/g" ./kubernetes/<< parameters.resource-type >>.yaml
+            sed -i "s/{{AWS_REGION}}/<< parameters.region >>/g" ./kubernetes/<< parameters.resource-type >>.yaml
             sed -i "s/{{IMAGE_TAG}}/${CIRCLE_SHA1}/g" ./kubernetes/<< parameters.resource-type >>.yaml
             sed -i "s/{{ENVIRONMENT}}/<< parameters.environment >>/g" ./kubernetes/<< parameters.resource-type >>.yaml
 


### PR DESCRIPTION
Sets `{{AWS_REGION}}` in kuberetes yaml in oot builds.
This is required for pods which need to sign requests with IAM credentials (e.g. oot-work-items-v2 which needs to sign its requests to Elasticsearch).