### PR TITLE
Bump oot-eks orb version

### DIFF
--- a/oot-eks/orb_version.txt
+++ b/oot-eks/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/oot-eks@1.1.0
+ovotech/oot-eks@1.2.0


### PR DESCRIPTION
This should have been updated in b18bda91c539adcabf018ffe80b37ea441c34221
(Set AWS_REGION in kubernetes yaml for oot services)