### PR TITLE
Added new oot-deploy orb.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,4 @@
 /clojure/                 @ovotech/orion-ops-tooling
 /ssh-proxy/               @ovotech/orion-security-engineering
 /jaws-journey-deploy      @ovotech/jaws
+/oot-deploy/              @ovotech/orion-ops-tooling

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Orbs follow the conventions:
  - [ovotech/with-git-deploy-key@1](with-git-deploy-key) - Execute Git operations on another repo selecting specific public key.
  - [ovotech/clojure](clojure) - test, scan and package Clojure projects built using Leiningen. 
  - [ovotech/oot-eks](oot-eks) - deploy services to EKS, OOT-style. 
+ - [ovotech/oot-deploy](oot-deploy) - deploy services via Argo, OOT-style. 
  
  Other orbs in the ovotech namespace:
  - [ovotech/shipit@1](https://github.com/ovotech/pe-orbs/tree/master/shipit) - Run shipit and record deployments to https://shipit.ovotech.org.uk.

--- a/oot-deploy/README.md
+++ b/oot-deploy/README.md
@@ -1,0 +1,71 @@
+OOT Deploy Orb [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/ovotech/oot-eks)](https://circleci.com/orbs/registry/orb/ovotech/oot-deploy)
+=====================
+
+Provides commands for packaging and deploying OOT images via [ArgoCD](https://argoproj.github.io/argo-cd/) and our gitops repo.
+
+The gitops repo is expected to have the structure:
+
+```
+<root>
+    - templates
+        - <service1>
+            - manifest.yaml
+        - <service2>
+            - manifest.yaml
+        ...
+        - <serviceN>
+            - manifest.yaml
+```
+
+What it does:
+
+1. Builds a new image based on the current project and pushes to an ECR registry named after the `service` parameter within the AWS account indicated by the `account` parameter.
+2. Clones the specified gitops repo. Then from within that cloned folder:
+3. Copies `./templates/<service>/manifest.yaml` to the `./<environment>/<service>/manifest.yaml`
+    - The `./<environment>/<service>` folder will be created if it does not already exist.
+4. Interpolates placeholders within  `./<environment>/<service>/manifest.yaml` as:
+    - `{{AWS_ACCOUNT_ID}}` will be swapped for the value of the `account` parameter.
+    - `{{ENVIRONMENT}}` will be swapped for the value of `environment` parameter.
+    - `{{IMAGE_TAG}}` will be swapped for the core CircleCI environment variable `${CIRCLE_SHA1}`
+5. Pushes the changes to the gitops repo as the github user `<gitops-username>`.
+
+From there, as long as the prerequisites below are configured properly, Argo should take over and pull the changes from `./<environment>/<service>/manifest.yaml`
+and deploy them to your kubernetes cluster.
+
+Prerequisites
+-------------
+* The source project is configured in Argo such that Argo watches the `./<environment>/<service>` folder for updates to deploy.  
+* A deploy key with push rights to the gitops repo has been assigned under "Additional SSH keys" in this source project.
+    - The host name should be "github.com".
+    - The fingerprint of this deploy key is the one used as the value of the `gitops-ssh-key-fingerprint` parameter.
+
+Example
+-------
+
+```yaml
+orbs:
+  oot-deploy: ovotech/oot-deploy@1.0.0
+
+jobs:
+  push-nonprod:
+    executor: oot-deploy/aws
+    steps:
+      - oot-deploy/push:
+          service: my-service
+          environment: nonprod
+          account: "1234567890"
+          gitops-repo: git@github.com:ovotech/my-gitops.git
+          gitops-ssh-key-fingerprint: "xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx"
+          gitops-username: my-bot
+          gitops-email: my-bot@myco.co.uk
+```
+
+This is what will happen upon running the `oot-deploy/push` command:
+
+1. A new image based on the current project source being deployed to an ECR registry called "my-service" within the AWS account 1234567890
+2. The gitops repo `git@github.com:ovotech/my-gitops.git` will be cloned; and then from within that folder...
+3. The `./templates/my-service/manifest.yaml` will be copied to `./nonprod/my-service/manifest.yaml` (the folder will be created if it does not already exist)
+4. `./nonprod/my-service/manifest.yaml` will be interpolated as described above.
+5. The changes to the gitops repo will be pushed as the github user `my-bot`.
+
+From there, Argo will take over. 

--- a/oot-deploy/orb.yml
+++ b/oot-deploy/orb.yml
@@ -1,0 +1,129 @@
+version: 2.1
+description: "Opinionated commands for releasing OOT projects on AWS EKS via k8s-proxy."
+
+orbs:
+  aws-cli: circleci/aws-cli@1.2.1
+  aws-ecr: circleci/aws-ecr@6.12.2
+  aws-eks: circleci/aws-eks@1.0.0
+  kubernetes: circleci/kubernetes@0.11.1
+  snyk: snyk/snyk@0.0.10
+  shipit: ovotech/shipit@1
+
+commands:
+  push:
+    description: "Builds and pushes a new service to ECR and then deploys that image to EKS."
+    parameters:
+      service:
+        description: "The name of the service that will be deployed. This will be used to build up the image name."
+        type: string
+      access-key-name:
+        description: "The name of the environment variable that will be used to provide the AWS access key id."
+        type: string
+        default: ACCESS_KEY_ID
+      secret-access-key-name:
+        description: "The name of the environment variable that will be used to provide the AWS secret access key."
+        type: string
+        default: SECRET_ACCESS_KEY
+      account:
+        description: "The numeric identifier for the AWS account on which the operation will be run."
+        type: string
+        default: ${AWS_ACCOUNT}
+      region:
+        description: "The AWS region on which the operation will be run."
+        type: string
+        default: eu-west-1
+      environment:
+        description: "Environment string used for substitution in the kubernetes files."
+        type: string
+        default: ${ENVIRONMENT}
+      gitops-repo:
+        description: "git URL to the gitops github repo."
+        type: string
+      gitops-ssh-key-fingerprint:
+        description: "The github SSH key that will be used to update the gitops repo."
+        type: string
+      gitops-username:
+        description: "The username of the git usere to push gitops changes as."
+        type: string
+      gitops-email:
+        description: "The email address of the git user to push gitops changes as."
+        type: string
+
+    steps:
+      - attach_workspace:
+          at: .
+
+      - run:
+          command: |
+            echo "export AWS_DEFAULT_REGION=<< parameters.region >>" >> $BASH_ENV
+            echo "export AWS_REGION=eu-west-1" >> $BASH_ENV
+            echo "export AWS_ECR_ACCOUNT_URL=<< parameters.account >>.dkr.ecr.<< parameters.region >>.amazonaws.com" >> $BASH_ENV
+
+      - aws-cli/install
+      - aws-cli/setup:
+          aws-access-key-id: << parameters.access-key-name >>
+          aws-secret-access-key: << parameters.secret-access-key-name >>
+
+      - aws-ecr/build-image:
+          account-url: AWS_ECR_ACCOUNT_URL
+          aws-access-key-id: << parameters.access-key-name >>
+          aws-secret-access-key: << parameters.secret-access-key-name >>
+          repo: << parameters.service >>
+          tag: ${CIRCLE_SHA1},latest
+          ecr-login: true
+
+      - snyk/scan:
+          monitor-on-build: true
+          severity-threshold: high
+          fail-on-issues: false
+          target-file: Dockerfile
+          docker-image-name: $AWS_ECR_ACCOUNT_URL/<< parameters.service >>:${CIRCLE_SHA1}
+
+      - aws-ecr/push-image:
+          repo: << parameters.service >>
+          tag: ${CIRCLE_SHA1},latest
+
+      - add_ssh_keys:
+          fingerprints:
+            - << parameters.ssh-key-fingerprint >>
+
+      - run:
+          name: Prepare gitops manifest
+          command: |
+            git clone << parameters.gitops-repo >> /tmp/gitops
+
+            mkdir -p /tmp/gitops/<< parameters.environment >>/<< parameters.service >>
+            cd /tmp/gitops/<< parameters.environment >>/<< parameters.service >>
+            cp /tmp/gitops/templates/<<parameters.service>>/manifest.yaml /tmp/gitops/<< parameters.environment >>/<< parameters.service >>
+
+      - run:
+          name: Interpolate gitops manifest
+          command: |
+            cd /tmp/gitops/<< parameters.environment >>/<< parameters.service >>
+            sed -i "s/{{AWS_ACCOUNT_ID}}/<< parameters.account >>/g" manifest.yaml
+            sed -i "s/{{IMAGE_TAG}}/${CIRCLE_SHA1}/g" manifest.yaml
+            sed -i "s/{{ENVIRONMENT}}/<< parameters.environment >>/g" manifest.yaml
+
+      - run:
+          name: Push gitops manifest
+          command: |
+            cd /tmp/gitops/<< parameters.environment >>/<< parameters.service >>
+            git config user.email "<< parameters.gitops-email >>"
+            git config user.name "<< parameters.gitops-username >>"
+            git add --all
+            git commit -m "Bumped << parameters.service >> in << parameters.environment >> to ${CIRCLE_SHA1}"
+            git push origin master
+
+jobs:
+  shipit:
+    description: "Alerts ShipIt to the fact that the service has been deployed."
+    executor: shipit/default
+    steps:
+      - shipit/shipit
+
+executors:
+  aws:
+    machine:
+      image: ubuntu-1604:202010-01
+
+

--- a/oot-deploy/orb_version.txt
+++ b/oot-deploy/orb_version.txt
@@ -1,0 +1,1 @@
+ovotech/oot-deploy@1.0.0


### PR DESCRIPTION
This orb is designed for OOT to use in deploying services via gitops using ArgoCD. However, it has been documented in such a way that it should be reusable by other folks (within the limits of the interpolation and expected gitops file structure anyway).
