### PR TITLE
Correct gitops-ssh-key-fingerprint parameter to oot-deploy orb.

### DIFF
--- a/oot-deploy/orb.yml
+++ b/oot-deploy/orb.yml
@@ -85,7 +85,7 @@ commands:
 
       - add_ssh_keys:
           fingerprints:
-            - << parameters.ssh-key-fingerprint >>
+            - << parameters.gitops-ssh-key-fingerprint >>
 
       - run:
           name: Prepare gitops manifest


### PR DESCRIPTION
Fixes this error: https://app.circleci.com/pipelines/github/ovotech/circleci-orbs/684/workflows/32813727-00a0-4bf2-bd26-f39f7a4a8a3c/jobs/4889