### PR TITLE
Split OOT image building and gitops deployment across two separate orbs for more flexible reuse.

### DIFF
--- a/oot-deploy/README.md
+++ b/oot-deploy/README.md
@@ -1,7 +1,8 @@
 OOT Deploy Orb [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/ovotech/oot-eks)](https://circleci.com/orbs/registry/orb/ovotech/oot-deploy)
 =====================
 
-Provides commands for packaging and deploying OOT images via [ArgoCD](https://argoproj.github.io/argo-cd/) and our gitops repo.
+Provides commands for packaging and deploying OOT images via our gitops repo. We use it with [ArgoCD](https://argoproj.github.io/argo-cd/) although
+there is no hard dependency on that application. 
 
 The gitops repo is expected to have the structure:
 
@@ -19,15 +20,14 @@ The gitops repo is expected to have the structure:
 
 What it does:
 
-1. Builds a new image based on the current project and pushes to an ECR registry named after the `service` parameter within the AWS account indicated by the `account` parameter.
-2. Clones the specified gitops repo. Then from within that cloned folder:
-3. Copies `./templates/<service>/manifest.yaml` to the `./<environment>/<service>/manifest.yaml`
+1. Clones the specified gitops repo. Then from within that cloned folder:
+2. Copies `./templates/<service>/manifest.yaml` to the `./<environment>/<service>/manifest.yaml`
     - The `./<environment>/<service>` folder will be created if it does not already exist.
-4. Interpolates placeholders within  `./<environment>/<service>/manifest.yaml` as:
+3. Interpolates placeholders within  `./<environment>/<service>/manifest.yaml` as:
     - `{{AWS_ACCOUNT_ID}}` will be swapped for the value of the `account` parameter.
     - `{{ENVIRONMENT}}` will be swapped for the value of `environment` parameter.
     - `{{IMAGE_TAG}}` will be swapped for the core CircleCI environment variable `${CIRCLE_SHA1}`
-5. Pushes the changes to the gitops repo as the github user `<gitops-username>`.
+4. Pushes the changes to the gitops repo as the github user `<gitops-username>`.
 
 From there, as long as the prerequisites below are configured properly, Argo should take over and pull the changes from `./<environment>/<service>/manifest.yaml`
 and deploy them to your kubernetes cluster.
@@ -44,13 +44,13 @@ Example
 
 ```yaml
 orbs:
-  oot-deploy: ovotech/oot-deploy@1.0.0
+  oot-deploy: ovotech/oot-deploy@2.0.0
 
 jobs:
-  push-nonprod:
+  update-gitops-nonprod:
     executor: oot-deploy/aws
     steps:
-      - oot-deploy/push:
+      - oot-deploy/update-gitops:
           service: my-service
           environment: nonprod
           account: "1234567890"
@@ -60,7 +60,7 @@ jobs:
           gitops-email: my-bot@myco.co.uk
 ```
 
-This is what will happen upon running the `oot-deploy/push` command:
+This is what will happen upon running the `update-gitops-nonprod` job:
 
 1. A new image based on the current project source being deployed to an ECR registry called "my-service" within the AWS account 1234567890
 2. The gitops repo `git@github.com:ovotech/my-gitops.git` will be cloned; and then from within that folder...

--- a/oot-deploy/orb.yml
+++ b/oot-deploy/orb.yml
@@ -1,39 +1,26 @@
 version: 2.1
-description: "Opinionated commands for releasing OOT projects on AWS EKS via k8s-proxy."
+description: "Update OOT deployments with gitops."
 
 orbs:
-  aws-cli: circleci/aws-cli@1.2.1
-  aws-ecr: circleci/aws-ecr@6.12.2
-  aws-eks: circleci/aws-eks@1.0.0
-  kubernetes: circleci/kubernetes@0.11.1
-  snyk: snyk/snyk@0.0.10
   shipit: ovotech/shipit@1
 
 commands:
-  push:
-    description: "Builds and pushes a new service to ECR and then deploys that image to EKS."
+  update-gitops:
+    description: "Updates the appropriate manifest in the given gitops repo with a new image tag."
     parameters:
       service:
-        description: "The name of the service that will be deployed. This will be used to build up the image name."
+        description: "The name of the service that will be updated. This should match with the path in the gitops repo."
         type: string
-      access-key-name:
-        description: "The name of the environment variable that will be used to provide the AWS access key id."
+      image-tag:
+        description: "The tag of the image to update the manifest with."
         type: string
-        default: ACCESS_KEY_ID
-      secret-access-key-name:
-        description: "The name of the environment variable that will be used to provide the AWS secret access key."
-        type: string
-        default: SECRET_ACCESS_KEY
+        default: ${CIRCLE_SHA1}
       account:
-        description: "The numeric identifier for the AWS account on which the operation will be run."
+        description: "The numeric identifier for the AWS account which will be interpolated into the manifest."
         type: string
         default: ${AWS_ACCOUNT}
-      region:
-        description: "The AWS region on which the operation will be run."
-        type: string
-        default: eu-west-1
       environment:
-        description: "Environment string used for substitution in the kubernetes files."
+        description: "Environment string used for substitution in the manifest and matching the appropriate path in the gitops repo."
         type: string
         default: ${ENVIRONMENT}
       gitops-repo:
@@ -43,7 +30,7 @@ commands:
         description: "The github SSH key that will be used to update the gitops repo."
         type: string
       gitops-username:
-        description: "The username of the git usere to push gitops changes as."
+        description: "The username of the git user to push gitops changes as."
         type: string
       gitops-email:
         description: "The email address of the git user to push gitops changes as."
@@ -52,36 +39,6 @@ commands:
     steps:
       - attach_workspace:
           at: .
-
-      - run:
-          command: |
-            echo "export AWS_DEFAULT_REGION=<< parameters.region >>" >> $BASH_ENV
-            echo "export AWS_REGION=eu-west-1" >> $BASH_ENV
-            echo "export AWS_ECR_ACCOUNT_URL=<< parameters.account >>.dkr.ecr.<< parameters.region >>.amazonaws.com" >> $BASH_ENV
-
-      - aws-cli/install
-      - aws-cli/setup:
-          aws-access-key-id: << parameters.access-key-name >>
-          aws-secret-access-key: << parameters.secret-access-key-name >>
-
-      - aws-ecr/build-image:
-          account-url: AWS_ECR_ACCOUNT_URL
-          aws-access-key-id: << parameters.access-key-name >>
-          aws-secret-access-key: << parameters.secret-access-key-name >>
-          repo: << parameters.service >>
-          tag: ${CIRCLE_SHA1},latest
-          ecr-login: true
-
-      - snyk/scan:
-          monitor-on-build: true
-          severity-threshold: high
-          fail-on-issues: false
-          target-file: Dockerfile
-          docker-image-name: $AWS_ECR_ACCOUNT_URL/<< parameters.service >>:${CIRCLE_SHA1}
-
-      - aws-ecr/push-image:
-          repo: << parameters.service >>
-          tag: ${CIRCLE_SHA1},latest
 
       - add_ssh_keys:
           fingerprints:
@@ -101,7 +58,7 @@ commands:
           command: |
             cd /tmp/gitops/<< parameters.environment >>/<< parameters.service >>
             sed -i "s/{{AWS_ACCOUNT_ID}}/<< parameters.account >>/g" manifest.yaml
-            sed -i "s/{{IMAGE_TAG}}/${CIRCLE_SHA1}/g" manifest.yaml
+            sed -i "s/{{IMAGE_TAG}}/<< parameters.image-tag >>/g" manifest.yaml
             sed -i "s/{{ENVIRONMENT}}/<< parameters.environment >>/g" manifest.yaml
 
       - run:
@@ -111,7 +68,7 @@ commands:
             git config user.email "<< parameters.gitops-email >>"
             git config user.name "<< parameters.gitops-username >>"
             git add --all
-            git commit -m "Bumped << parameters.service >> in << parameters.environment >> to ${CIRCLE_SHA1}"
+            git commit -m "Bumped << parameters.service >> in << parameters.environment >> to << parameters.image-tag >>"
             git push origin master
 
 jobs:
@@ -120,10 +77,5 @@ jobs:
     executor: shipit/default
     steps:
       - shipit/shipit
-
-executors:
-  aws:
-    machine:
-      image: ubuntu-1604:202010-01
 
 

--- a/oot-deploy/orb_version.txt
+++ b/oot-deploy/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/oot-deploy@1.0.0
+ovotech/oot-deploy@2.0.0

--- a/oot-eks/README.md
+++ b/oot-eks/README.md
@@ -1,9 +1,33 @@
 OOT EKS Orb [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/ovotech/oot-eks)](https://circleci.com/orbs/registry/orb/ovotech/oot-eks)
 =====================
 
-Provides commands for packaging and deploying images to [AWS EKS](https://aws.amazon.com/eks/).
+Provides commands for packaging images for deployment to [AWS EKS](https://aws.amazon.com/eks/).
 
-It is quite opinionated about what files exist and where. Here is a summary:
+Prerequisites
+-------------
+* An [AWS ECR registry](https://aws.amazon.com/ecr/) with the same name as the service being deployed exists on the same AWS account.
 
-* A file called `kubernetes/deployment.yaml` is expected to exist describing the [kubernetes deployment](https://v1-17.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#deployment-v1-apps).
-* An [AWS ECR registry](https://aws.amazon.com/ecr/) with the same name as the service being deployed exists on the same AWS account.  
+Example
+-------
+
+```yaml
+orbs:
+  oot-eks: ovotech/oot-eks@2.0.0
+
+jobs:
+  push-image-nonprod:
+    executor: oot-eks/aws
+    steps:
+      - oot-eks/push-image:
+          service: my-service
+          account: "1234567890"
+```
+
+This is what will happen upon running the `push-image-nonprod` job:
+
+1. A new docker image is built from the current source.
+2. The image is scanned for vulnerabilities by Snyk.
+3. The image is pushed to an ECR registry called "my-service" within the AWS account 1234567890
+
+
+  

--- a/oot-eks/orb.yml
+++ b/oot-eks/orb.yml
@@ -1,24 +1,17 @@
 version: 2.1
-description: "Opinionated commands for releasing OOT projects on AWS EKS via k8s-proxy."
+description: "Opinionated commands for releasing OOT projects on AWS EKS via ECR."
 
 orbs:
   aws-cli: circleci/aws-cli@1.2.1
   aws-ecr: circleci/aws-ecr@6.12.2
-  aws-eks: circleci/aws-eks@1.0.0
-  kubernetes: circleci/kubernetes@0.11.1
   snyk: snyk/snyk@0.0.10
-  ssh-proxy: ovotech/ssh-proxy@1.0.0
-  shipit: ovotech/shipit@1
 
 commands:
-  push:
-    description: "Builds and pushes a new service to ECR and then deploys that image to EKS."
+  push-image:
+    description: "Builds, scans and pushes a new service to ECR."
     parameters:
       service:
         description: "The name of the service that will be deployed. This will be used to build up the image name."
-        type: string
-      eks-cluster-name:
-        description: "The name of the AWS EKS cluster to be deployed to."
         type: string
       access-key-name:
         description: "The name of the environment variable that will be used to provide the AWS access key id."
@@ -36,43 +29,10 @@ commands:
         description: "The AWS region on which the operation will be run."
         type: string
         default: eu-west-1
-      environment:
-        description: "Environment string used for substitution in the kubernetes files."
-        type: string
-        default: ${ENVIRONMENT}
-      resource-type:
-        description: "The kubernetes resource type that will be deployed."
-        type: string
-        default: "deployment"
-      k8s-api-host:
-        description: "The hostname of the kubernetes API to be pushed to."
-        type: string
-        default: ${K8S_API_HOST}
-      k8s-proxy-fingerprint:
-        description: "The fingerprint of the private key used by the k8s-proxy running in your cluster."
-        type: string
-        default: ${K8S_PROXY_FINGERPRINT}
-      k8s-endpoint1:
-        description: "Kubernetes private endpoint 1."
-        type: string
-        default: ${K8S_ENDPOINT1}
-      k8s-endpoint2:
-        description: "Kubernetes private endpoint 2."
-        type: string
-        default: ${K8S_ENDPOINT2}
 
     steps:
       - attach_workspace:
           at: .
-
-      - ssh-proxy/proxy-up:
-          hostname: << parameters.k8s-api-host >>
-          port: 443
-          username: proxy
-          private_key_fingerprint: << parameters.k8s-proxy-fingerprint >>
-          routed_network_cidrs: << parameters.k8s-endpoint1 >>/32 << parameters.k8s-endpoint2 >>/32
-          connection_test_host: << parameters.k8s-endpoint1 >>
-          connection_test_port: 443
 
       - run:
           command: |
@@ -103,34 +63,6 @@ commands:
       - aws-ecr/push-image:
           repo: << parameters.service >>
           tag: ${CIRCLE_SHA1},latest
-
-      - run:
-          command: |
-            sed -i "s/{{AWS_ACCOUNT_ID}}/<< parameters.account >>/g" ./kubernetes/<< parameters.resource-type >>.yaml
-            sed -i "s/{{AWS_REGION}}/<< parameters.region >>/g" ./kubernetes/<< parameters.resource-type >>.yaml
-            sed -i "s/{{IMAGE_TAG}}/${CIRCLE_SHA1}/g" ./kubernetes/<< parameters.resource-type >>.yaml
-            sed -i "s/{{ENVIRONMENT}}/<< parameters.environment >>/g" ./kubernetes/<< parameters.resource-type >>.yaml
-
-      - aws-eks/update-kubeconfig-with-authenticator:
-          authenticator-release-tag: v0.5.1
-          cluster-name: << parameters.eks-cluster-name >>
-          aws-region: << parameters.region >>
-          install-kubectl: true
-
-      - kubernetes/create-or-update-resource:
-          get-rollout-status: true
-          resource-file-path: kubernetes/<< parameters.resource-type >>.yaml
-          resource-name: << parameters.resource-type >>/<< parameters.service >>
-          show-kubectl-command: true
-
-      - ssh-proxy/proxy-down
-
-jobs:
-  shipit:
-    description: "Alerts ShipIt to the fact that the service has been deployed."
-    executor: shipit/default
-    steps:
-      - shipit/shipit
 
 executors:
   aws:

--- a/oot-eks/orb_version.txt
+++ b/oot-eks/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/oot-eks@1.2.0
+ovotech/oot-eks@2.0.0


### PR DESCRIPTION
The main purpose of this PR is to split the functionality building OOT docker images (`oot-eks`) apart into an orb separate from the functionality to update our gitops repo (`oot-deploy`). The key advantage of this is it potentially allows other teams to use the `oot-deploy` orb without having to also be on AWS EKS.

`oot-eks` becomes something of a misnomer (`oot-ecr` would be more accurate now) but given that this is a team specific orb, the confusion is going to be minimal.

Because of the major changes, both orbs are bumped a major version number.