### PR TITLE
Create argo application resource as part of oot-deploy gitops process.

### DIFF
--- a/oot-deploy/orb.yml
+++ b/oot-deploy/orb.yml
@@ -62,9 +62,23 @@ commands:
             sed -i "s/{{ENVIRONMENT}}/<< parameters.environment >>/g" manifest.yaml
 
       - run:
+          name: Prepare argo application manifest
+          command: |
+            mkdir -p /tmp/gitops/<< parameters.environment >>/argo-applications
+            cd /tmp/gitops/<< parameters.environment >>/argo-applications
+            cp /tmp/gitops/templates/argo-applications/manifest.yaml /tmp/gitops/<< parameters.environment >>/argo-applications/<< parameters.service >>.yaml
+
+      - run:
+          name: Interpolate argo application definition
+          command: |
+            cd /tmp/gitops/<< parameters.environment >>/argo-applications
+            sed -i "s/{{ENVIRONMENT}}/<< parameters.environment >>/g" << parameters.service >>.yaml
+            sed -i "s/{{SERVICE}}/<< parameters.service >>/g" << parameters.service >>.yaml
+
+      - run:
           name: Push gitops manifest
           command: |
-            cd /tmp/gitops/<< parameters.environment >>/<< parameters.service >>
+            cd /tmp/gitops
             git config user.email "<< parameters.gitops-email >>"
             git config user.name "<< parameters.gitops-username >>"
             git add --all

--- a/oot-deploy/orb_version.txt
+++ b/oot-deploy/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/oot-deploy@2.0.0
+ovotech/oot-deploy@2.1.0


### PR DESCRIPTION
Rather than relying on users adding new services to Argo by hand in the Argo console, get the `oot-deploy` orb to do the hard work of generating a [argoproj.io/v1alpha1](https://argoproj.github.io/argo-cd/operator-manual/application.yaml) resource representing the service being deployed.
