### PR TITLE
Fix empty plan in PR comments with terraform 0.14

### DIFF
--- a/terraform/CHANGELOG.md
+++ b/terraform/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
 not listed
 
+## ovotech/terraform@1.8.1
+## Fixed
+- PR comment plan is empty with Terraform 0.14.0
+
 ## ovotech/terraform@1.8.0
 ## Changed
 - Updated terraform-0.13 executor to include:

--- a/terraform/apply.sh
+++ b/terraform/apply.sh
@@ -49,7 +49,7 @@ set +e
 terraform plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS "$module_path" \
     | $TFMASK \
     | tee /dev/fd/3 \
-    | sed '1,/---/d' \
+    | $COMPACT_PLAN \
         >plan.txt
 
 TF_EXIT=${PIPESTATUS[0]}

--- a/terraform/check.sh
+++ b/terraform/check.sh
@@ -4,7 +4,7 @@ set +e
 terraform plan -input=false -no-color -detailed-exitcode -lock-timeout=300s $PLAN_ARGS "$module_path" \
     | $TFMASK \
     | tee /dev/fd/3 \
-    | sed '1,/---/d' \
+    | $COMPACT_PLAN \
         >plan.txt
 
 readonly TF_EXIT=${PIPESTATUS[0]}

--- a/terraform/executor/Dockerfile-0.11
+++ b/terraform/executor/Dockerfile-0.11
@@ -113,4 +113,6 @@ COPY --from=tfmask /go/tfmask/release/tfmask /usr/local/bin/tfmask
 ENV TFMASK_RESOURCES_REGEX="(?i)^(random_id|kubernetes_secret|acme_certificate).*$"
 ENV TFENV="0.11"
 
+COPY compact_plan.py /usr/local/bin/compact_plan
+
 ENTRYPOINT ["/usr/local/bin/terraform"]

--- a/terraform/executor/Dockerfile-0.12
+++ b/terraform/executor/Dockerfile-0.12
@@ -107,4 +107,6 @@ RUN pip3 install awscli==$AWSCLI_VERSION
 COPY --from=tfmask /go/tfmask/release/tfmask /usr/local/bin/tfmask
 ENV TFMASK_RESOURCES_REGEX="(?i)^(random_id|kubernetes_secret|acme_certificate).*$"
 
+COPY compact_plan.py /usr/local/bin/compact_plan
+
 ENTRYPOINT ["/usr/local/bin/terraform"]

--- a/terraform/executor/Dockerfile-0.12-slim
+++ b/terraform/executor/Dockerfile-0.12-slim
@@ -93,4 +93,6 @@ RUN pip3 install --no-cache-dir awscli==$AWSCLI_VERSION
 COPY --from=tfmask /go/tfmask/release/tfmask /usr/local/bin/tfmask
 ENV TFMASK_RESOURCES_REGEX="(?i)^(random_id|kubernetes_secret|acme_certificate).*$"
 
+COPY compact_plan.py /usr/local/bin/compact_plan
+
 ENTRYPOINT ["/usr/local/bin/terraform"]

--- a/terraform/executor/Dockerfile-0.13
+++ b/terraform/executor/Dockerfile-0.13
@@ -98,4 +98,6 @@ RUN pip3 install awscli==$AWSCLI_VERSION
 COPY --from=tfmask /go/tfmask/release/tfmask /usr/local/bin/tfmask
 ENV TFMASK_RESOURCES_REGEX="(?i)^(random_id|kubernetes_secret|acme_certificate).*$"
 
+COPY compact_plan.py /usr/local/bin/compact_plan
+
 ENTRYPOINT ["/usr/local/bin/terraform"]

--- a/terraform/executor/compact_plan.py
+++ b/terraform/executor/compact_plan.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import sys
+
+
+def compact_plan(input):
+    plan = False
+    buffer = []
+
+    for line in input:
+
+        if not plan and (
+            line.startswith('An execution plan has been generated and is shown below') or
+            line.startswith('No changes') or
+            line.startswith('Error')
+        ):
+            plan = True
+
+        if plan:
+            yield line
+        else:
+            buffer.append(line)
+
+    if not plan and buffer:
+        yield from buffer
+
+
+if __name__ == '__main__':
+    for line in compact_plan(sys.stdin.readlines()):
+        sys.stdout.write(line)

--- a/terraform/executor/test_compact_plan.py
+++ b/terraform/executor/test_compact_plan.py
@@ -1,0 +1,258 @@
+from compact_plan import compact_plan
+
+
+def test_plan_11():
+    input = """Refreshing Terraform state in-memory prior to plan...
+The refreshed state will be used to calculate this plan, but will not be
+persisted to local or remote state storage.
+
+
+------------------------------------------------------------------------
+
+An execution plan has been generated and is shown below.
+Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
++ random_string.my_string
+      id:          <computed>
+      length:      "11"
+      lower:       "true"
+      min_lower:   "0"
+      min_numeric: "0"
+      min_special: "0"
+      min_upper:   "0"
+      number:      "true"
+      result:      <computed>
+      special:     "true"
+      upper:       "true"
+Plan: 1 to add, 0 to change, 0 to destroy.
+"""
+
+    expected_output = """An execution plan has been generated and is shown below.
+Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
++ random_string.my_string
+      id:          <computed>
+      length:      "11"
+      lower:       "true"
+      min_lower:   "0"
+      min_numeric: "0"
+      min_special: "0"
+      min_upper:   "0"
+      number:      "true"
+      result:      <computed>
+      special:     "true"
+      upper:       "true"
+Plan: 1 to add, 0 to change, 0 to destroy."""
+
+    output = '\n'.join(compact_plan(input.splitlines()))
+    assert output == expected_output
+
+def test_plan_12():
+    input = """Refreshing Terraform state in-memory prior to plan...
+The refreshed state will be used to calculate this plan, but will not be
+persisted to local or remote state storage.
+
+
+------------------------------------------------------------------------
+
+An execution plan has been generated and is shown below.
+Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # random_string.my_string will be created
+  + resource "random_string" "my_string" {
+      + id          = (known after apply)
+      + length      = 11
+      + lower       = true
+      + min_lower   = 0
+      + min_numeric = 0
+      + min_special = 0
+      + min_upper   = 0
+      + number      = true
+      + result      = (known after apply)
+      + special     = true
+      + upper       = true
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+"""
+
+    expected_output = """An execution plan has been generated and is shown below.
+Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # random_string.my_string will be created
+  + resource "random_string" "my_string" {
+      + id          = (known after apply)
+      + length      = 11
+      + lower       = true
+      + min_lower   = 0
+      + min_numeric = 0
+      + min_special = 0
+      + min_upper   = 0
+      + number      = true
+      + result      = (known after apply)
+      + special     = true
+      + upper       = true
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy."""
+
+    output = '\n'.join(compact_plan(input.splitlines()))
+    assert output == expected_output
+
+def test_plan_14():
+    input = """
+An execution plan has been generated and is shown below.
+Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # random_string.my_string will be created
+  + resource "random_string" "my_string" {
+      + id          = (known after apply)
+      + length      = 11
+      + lower       = true
+      + min_lower   = 0
+      + min_numeric = 0
+      + min_special = 0
+      + min_upper   = 0
+      + number      = true
+      + result      = (known after apply)
+      + special     = true
+      + upper       = true
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+
+Changes to Outputs:
+  + s = "string"
+"""
+
+    expected_output = """An execution plan has been generated and is shown below.
+Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+  # random_string.my_string will be created
+  + resource "random_string" "my_string" {
+      + id          = (known after apply)
+      + length      = 11
+      + lower       = true
+      + min_lower   = 0
+      + min_numeric = 0
+      + min_special = 0
+      + min_upper   = 0
+      + number      = true
+      + result      = (known after apply)
+      + special     = true
+      + upper       = true
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+
+Changes to Outputs:
+  + s = "string\""""
+
+    output = '\n'.join(compact_plan(input.splitlines()))
+    assert output == expected_output
+
+def test_error_11():
+    input = """
+Error: random_string.my_string: length: cannot parse '' as int: strconv.ParseInt: parsing "ten": invalid syntax
+
+"""
+
+    expected_output = """Error: random_string.my_string: length: cannot parse '' as int: strconv.ParseInt: parsing "ten": invalid syntax
+"""
+
+    output = '\n'.join(compact_plan(input.splitlines()))
+    assert output == expected_output
+
+def test_error_12():
+    input = """
+Error: Incorrect attribute value type
+
+  on main.tf line 2, in resource "random_string" "my_string":
+   2:   length      = "ten"
+
+Inappropriate value for attribute "length": a number is required.
+"""
+
+    expected_output = """Error: Incorrect attribute value type
+
+  on main.tf line 2, in resource "random_string" "my_string":
+   2:   length      = "ten"
+
+Inappropriate value for attribute "length": a number is required."""
+
+    output = '\n'.join(compact_plan(input.splitlines()))
+    assert output == expected_output
+
+def test_no_change_11():
+    input = """Refreshing Terraform state in-memory prior to plan...
+The refreshed state will be used to calculate this plan, but will not be
+persisted to local or remote state storage.
+
+
+------------------------------------------------------------------------
+
+No changes. Infrastructure is up-to-date.
+
+This means that Terraform did not detect any differences between your
+configuration and real physical resources that exist. As a result, no
+actions need to be performed.
+"""
+
+    expected_output = """No changes. Infrastructure is up-to-date.
+
+This means that Terraform did not detect any differences between your
+configuration and real physical resources that exist. As a result, no
+actions need to be performed."""
+
+    output = '\n'.join(compact_plan(input.splitlines()))
+    assert output == expected_output
+
+def test_no_change_14():
+    input = """
+No changes. Infrastructure is up-to-date.
+
+This means that Terraform did not detect any differences between your
+configuration and real physical resources that exist. As a result, no
+actions need to be performed.
+"""
+
+    expected_output = """No changes. Infrastructure is up-to-date.
+
+This means that Terraform did not detect any differences between your
+configuration and real physical resources that exist. As a result, no
+actions need to be performed."""
+
+    output = '\n'.join(compact_plan(input.splitlines()))
+    assert output == expected_output
+
+def test_no_output():
+    input = """
+This is not anything like terraform output we know. We want this to be output unchanged.
+This should protect against the output changing again.
+"""
+
+    expected_output = """
+This is not anything like terraform output we know. We want this to be output unchanged.
+This should protect against the output changing again."""
+
+    output = '\n'.join(compact_plan(input.splitlines()))
+    assert output == expected_output
+

--- a/terraform/orb_version.txt
+++ b/terraform/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform@1.8.0
+ovotech/terraform@1.8.1

--- a/terraform/plan.sh
+++ b/terraform/plan.sh
@@ -12,7 +12,7 @@ set +e
 terraform plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS "$module_path" \
     | $TFMASK \
     | tee /dev/fd/3 \
-    | sed '1,/---/d' \
+    | $COMPACT_PLAN \
         >plan.txt
 
 readonly TF_EXIT=${PIPESTATUS[0]}

--- a/terraform/setup.sh
+++ b/terraform/setup.sh
@@ -62,3 +62,9 @@ TFMASK=tfmask
 if ! hash $TFMASK 2>/dev/null; then
     TFMASK=cat
 fi
+
+# Detect compact_plan
+COMPACT_PLAN=compact_plan
+if ! hash $COMPACT_PLAN 2>/dev/null; then
+    COMPACT_PLAN=cat
+fi


### PR DESCRIPTION
With Terraform 0.14, the plan output no longer has the `----` separator line between the boring bit and the interesting bit of the plan.
If we want to work with versions past 0.14, we need to be a bit smarter.