### PR TITLE
Specify updated stable repo for helm 2

### DIFF
--- a/terraform/CHANGELOG.md
+++ b/terraform/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
 not listed
 
+## ovotech/terraform@1.8.2
+## Fixed
+- Helm 2 init failing as the stable and incubator repositories have moved to a new location
+    - Added stable-repo-url option to helm init with new repo
+
 ## ovotech/terraform@1.8.1
 ## Fixed
 - PR comment plan is empty with Terraform 0.14.0

--- a/terraform/executor/Dockerfile-0.11
+++ b/terraform/executor/Dockerfile-0.11
@@ -70,7 +70,7 @@ RUN mkdir -p /root/aiven \
 RUN curl -fsL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" | tar -xzvf- \
  && mv linux-amd64/helm /usr/local/bin/helm \
  && rm -rf helm*.tar.gz linux-amd64/ \
- && helm init --client-only
+ && helm init --stable-repo-url=https://charts.helm.sh/stable --client-only
 ENV HELM_HOME /root/.helm
 
 # This is extremely slow for some reason

--- a/terraform/executor/Dockerfile-0.12
+++ b/terraform/executor/Dockerfile-0.12
@@ -74,7 +74,7 @@ RUN curl -fsL "https://get.helm.sh/helm-v${HELM2_VERSION}-linux-amd64.tar.gz" | 
  && mv linux-amd64/helm /usr/local/bin/helm2 \
  && rm -rf helm*.tar.gz linux-amd64/ \
  && ln -s /usr/local/bin/helm2 /usr/local/bin/helm \
- && helm init --client-only
+ && helm init --stable-repo-url=https://charts.helm.sh/stable --client-only
 ENV HELM_HOME /root/.helm
 
 # helm 3

--- a/terraform/executor/Dockerfile-0.12-slim
+++ b/terraform/executor/Dockerfile-0.12-slim
@@ -60,7 +60,7 @@ RUN curl -fsL "https://get.helm.sh/helm-v${HELM2_VERSION}-linux-amd64.tar.gz" | 
  && mv linux-amd64/helm /usr/local/bin/helm2 \
  && rm -rf helm*.tar.gz linux-amd64/ \
  && ln -s /usr/local/bin/helm2 /usr/local/bin/helm \
- && helm init --client-only
+ && helm init --stable-repo-url=https://charts.helm.sh/stable --client-only
 ENV HELM_HOME /root/.helm
 
 # helm 3

--- a/terraform/executor/Dockerfile-0.13
+++ b/terraform/executor/Dockerfile-0.13
@@ -63,7 +63,7 @@ RUN curl -fsL "https://get.helm.sh/helm-v${HELM2_VERSION}-linux-amd64.tar.gz" | 
  && mv linux-amd64/helm /usr/local/bin/helm2 \
  && rm -rf helm*.tar.gz linux-amd64/ \
  && ln -s /usr/local/bin/helm2 /usr/local/bin/helm \
- && helm init --client-only
+ && helm init --stable-repo-url=https://charts.helm.sh/stable --client-only
 ENV HELM_HOME /root/.helm
 
 # helm 3

--- a/terraform/orb_version.txt
+++ b/terraform/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform@1.8.1
+ovotech/terraform@1.8.2


### PR DESCRIPTION
Build for the tf orb has been failing with 

`Error: error initializing: Looks like "https://kubernetes-charts.storage.googleapis.com" is not a valid chart repository or cannot be reached: Failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden`

Guided by https://helm.sh/blog/new-location-stable-incubator-charts/ and https://stackoverflow.com/questions/61954440/how-to-resolve-https-kubernetes-charts-storage-googleapis-com-is-not-a-valid , adds the updated stable repo url.