### PR TITLE
Make Terraform Plan Comments Collapsible

### DIFF
--- a/terraform/comment_util.py
+++ b/terraform/comment_util.py
@@ -18,4 +18,5 @@ def comment_for_pr(comment_id, plan):
     ```hcl
     {plan}
     ```
-    </details>""")
+    </details>
+    """)

--- a/terraform/comment_util.py
+++ b/terraform/comment_util.py
@@ -1,5 +1,4 @@
 import re
-import textwrap
 
 
 def re_comment_match(comment_id, comment_body):
@@ -10,13 +9,4 @@ def re_comment_match(comment_id, comment_body):
 
 def comment_for_pr(comment_id, plan):
     """Returns a formatted string containing comment_id and plan"""
-    return textwrap.dedent(f"""\
-    {comment_id}
-    <details open>
-    <summary>Plan</summary>
-    
-    ```hcl
-    {plan}
-    ```
-    </details>
-    """)
+    return f"{comment_id}\n<details open>\n<summary>Plan</summary>\n\n```hcl\n{plan}\n```\n</details>\n"

--- a/terraform/comment_util.py
+++ b/terraform/comment_util.py
@@ -1,4 +1,5 @@
 import re
+import textwrap
 
 
 def re_comment_match(comment_id, comment_body):
@@ -9,4 +10,12 @@ def re_comment_match(comment_id, comment_body):
 
 def comment_for_pr(comment_id, plan):
     """Returns a formatted string containing comment_id and plan"""
-    return f'{comment_id}\n```hcl\n{plan}\n```'
+    return textwrap.dedent(f"""\
+    {comment_id}
+    <details open>
+    <summary>Plan</summary>
+    
+    ```hcl
+    {plan}
+    ```
+    </details>""")

--- a/terraform/orb_version.txt
+++ b/terraform/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform@1.8.2
+ovotech/terraform@1.8.3

--- a/terraform/test_comment_util.py
+++ b/terraform/test_comment_util.py
@@ -1,3 +1,5 @@
+import textwrap
+
 import comment_util
 import pytest
 
@@ -26,4 +28,13 @@ def test_regex_comment_match(comment_id, comment_body,
 
 def test_comment_for_pr():
     comment_for_pr = comment_util.comment_for_pr("<comment_id>", "<plan>")
-    assert comment_for_pr == "<comment_id>\n<details open>\n<summary>Plan</summary>\n\n```hcl\n<plan>\n```\n</details>\n"
+    assert comment_for_pr == textwrap.dedent("""\
+    <comment_id>
+    <details open>
+    <summary>Plan</summary>
+    
+    ```hcl
+    <plan>
+    ```
+    </details>
+    """)

--- a/terraform/test_comment_util.py
+++ b/terraform/test_comment_util.py
@@ -1,23 +1,22 @@
-import pytest
-
 import comment_util
+import pytest
 
 
 @pytest.mark.parametrize("comment_id,comment_body,match_group_one,match_group_two",
                          [
-                             #  pre addition of HCL syntax formatting
+                            #  pre addition of HCL syntax formatting
                              ("<comment_id>",
                               "<comment_id>\n```\n<plan>\n```<status>",
                               "<plan>",
                               "<status>"
-                              ),
-                             #  post addition of HCL syntax formatting
+                             ),
+                            #  post addition of HCL syntax formatting
                              ("<comment_id>",
                               "<comment_id>\n```hcl\n<plan>\n```<status>",
                               "<plan>",
                               "<status>"
-                              ),
-                         ])
+                             ),
+                          ])
 def test_regex_comment_match(comment_id, comment_body,
                              match_group_one, match_group_two):
     match = comment_util.re_comment_match(comment_id, comment_body)

--- a/terraform/test_comment_util.py
+++ b/terraform/test_comment_util.py
@@ -26,4 +26,4 @@ def test_regex_comment_match(comment_id, comment_body,
 
 def test_comment_for_pr():
     comment_for_pr = comment_util.comment_for_pr("<comment_id>", "<plan>")
-    assert comment_for_pr == "<comment_id>\n```hcl\n<plan>\n```"
+    assert comment_for_pr == "<comment_id>\n<details open>\n<summary>Plan</summary>\n\n```hcl\n<plan>\n```\n</details>"

--- a/terraform/test_comment_util.py
+++ b/terraform/test_comment_util.py
@@ -1,23 +1,24 @@
-import comment_util
 import pytest
+
+import comment_util
 
 
 @pytest.mark.parametrize("comment_id,comment_body,match_group_one,match_group_two",
                          [
-                            #  pre addition of HCL syntax formatting
+                             #  pre addition of HCL syntax formatting
                              ("<comment_id>",
                               "<comment_id>\n```\n<plan>\n```<status>",
                               "<plan>",
                               "<status>"
-                             ),
-                            #  post addition of HCL syntax formatting
+                              ),
+                             #  post addition of HCL syntax formatting
                              ("<comment_id>",
                               "<comment_id>\n```hcl\n<plan>\n```<status>",
                               "<plan>",
                               "<status>"
-                             ),
-                          ])
-def test_regex_comment_match(comment_id, comment_body, 
+                              ),
+                         ])
+def test_regex_comment_match(comment_id, comment_body,
                              match_group_one, match_group_two):
     match = comment_util.re_comment_match(comment_id, comment_body)
     assert match.group(1).strip() == match_group_one
@@ -26,4 +27,4 @@ def test_regex_comment_match(comment_id, comment_body,
 
 def test_comment_for_pr():
     comment_for_pr = comment_util.comment_for_pr("<comment_id>", "<plan>")
-    assert comment_for_pr == "<comment_id>\n<details open>\n<summary>Plan</summary>\n\n```hcl\n<plan>\n```\n</details>"
+    assert comment_for_pr == "<comment_id>\n<details open>\n<summary>Plan</summary>\n\n```hcl\n<plan>\n```\n</details>\n"


### PR DESCRIPTION
Good afternoon

Terraform plan comments can get pretty long sometimes, so I thought this would be useful.

The plans would be open by default and can be collapsed.

They look like this:

Terraform plan for __non-prod-cluster__
<details open>
<summary>Plan</summary>

```hcl
No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.

Warning: Version constraints inside provider configuration blocks are deprecated

  on cluster/main.tf line 29, in provider "aws":
  29:   version = ">= 2.28.1"

Terraform 0.13 and earlier allowed provider version constraints inside the
provider configuration block, but that is now deprecated and will be removed
in a future version of Terraform. To silence this warning, move the provider
version constraint into the required_providers block.

Releasing state lock. This may take a few moments...
```
</details>

Plan generated in CircleCI Job [non-prod-plan 991](https://circleci.com/gh/ovotech/smart-bookings-terraform/991)