### PR TITLE
Add conditional to enable Monitoring in Snyk

### DIFF
--- a/versioned-lambda/orb.yml
+++ b/versioned-lambda/orb.yml
@@ -33,6 +33,10 @@ jobs:
         description: "Whether or not to authenticate with the npm registry service. Defaults to true"
         type: boolean
         default: true
+      monitor-branch:
+        description: "If true, monitors the state of this branch in Snyk. Defaults to false."
+        type: boolean
+        default: false
     executor: << parameters.executor >>
     steps:
       - checkout
@@ -59,24 +63,11 @@ jobs:
             - run:
                 name: Sudo install
                 command: yum install -y sudo
-            - when:
-                condition:
-                  equal: [master, $CIRCLE_BRANCH]
-                steps:
-                  snyk/scan:
-                    token-variable: SNYK_TOKEN
-                    monitor-on-build: true
-                    severity-threshold: low
-                    project: ${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}
-            - unless:
-                condition:
-                  equal: [master, $CIRCLE_BRANCH]
-                steps:
-                  snyk/scan:
-                    token-variable: SNYK_TOKEN
-                    monitor-on-build: false
-                    severity-threshold: low
-                    project: ${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}
+            - snyk/scan:
+                token-variable: SNYK_TOKEN
+                monitor-on-build: << parameters.monitor-branch >>
+                severity-threshold: low
+                project: ${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}
       - run:
           name: Lint
           command: npm run lint

--- a/versioned-lambda/orb.yml
+++ b/versioned-lambda/orb.yml
@@ -61,7 +61,7 @@ jobs:
                 command: yum install -y sudo
             - when:
                 condition:
-                  equal: [master, << pipeline.git.branch >>]
+                  equal: [master, $CIRCLE_BRANCH]
                 steps:
                   snyk/scan:
                     token-variable: SNYK_TOKEN
@@ -70,7 +70,7 @@ jobs:
                     project: ${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}
             - unless:
                 condition:
-                  equal: [master, << pipeline.git.branch >>]
+                  equal: [master, $CIRCLE_BRANCH]
                 steps:
                   snyk/scan:
                     token-variable: SNYK_TOKEN

--- a/versioned-lambda/orb.yml
+++ b/versioned-lambda/orb.yml
@@ -59,11 +59,24 @@ jobs:
             - run:
                 name: Sudo install
                 command: yum install -y sudo
-            - snyk/scan:
-                token-variable: SNYK_TOKEN
-                monitor-on-build: true
-                severity-threshold: low
-                project: ${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}
+            - when:
+                condition:
+                  equal: [master, << pipeline.git.branch >>]
+                steps:
+                  snyk/scan:
+                    token-variable: SNYK_TOKEN
+                    monitor-on-build: true
+                    severity-threshold: low
+                    project: ${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}
+            - unless:
+                condition:
+                  equal: [master, << pipeline.git.branch >>]
+                steps:
+                  snyk/scan:
+                    token-variable: SNYK_TOKEN
+                    monitor-on-build: false
+                    severity-threshold: low
+                    project: ${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BRANCH}
       - run:
           name: Lint
           command: npm run lint


### PR DESCRIPTION
Adds a flag to indicate whether the build should be monitored in Snyk, this defaults to false to avoid excessive monitoring of branches.