### PR TITLE
Add GCP Rotate Keys orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,4 +161,5 @@ workflows:
                 - ssh-proxy
                 - jaws-journey-deploy
                 - oot-deploy
+                - gcp-rotate-keys
 

--- a/gcp-rotate-keys/README.md
+++ b/gcp-rotate-keys/README.md
@@ -78,4 +78,4 @@ Parameters:
 ## Limitations
 
 Currently the commands will abort without doing anything if the service account
-has more than key.
+has more than one key.

--- a/gcp-rotate-keys/README.md
+++ b/gcp-rotate-keys/README.md
@@ -25,11 +25,11 @@ orb for one way to handle authentication.
 
 The command makes available three environment variables so that the processing
 stage can do things with the keys:
-* `ROTATED_KEY_PATH` - Path containing the exported JSON key file
-* `ROTATED_KEY_ID` - ID of the key that has been created
+* `GENERATED_KEY_PATH` - Path containing the exported JSON key file
+* `GENERATED_KEY_ID` - ID of the key that has been created
 * `PREVIOUS_KEY_ID` - ID of the key that is being rotated out
 
-The JSON key file at `ROTATED_KEY_PATH` is deleted after this command finishes.
+The JSON key file at `GENERATED_KEY_PATH` is deleted after this command finishes.
 
 Parameters:
 * `service-account` - The service account email address to rotate the key of

--- a/gcp-rotate-keys/README.md
+++ b/gcp-rotate-keys/README.md
@@ -1,0 +1,81 @@
+# GCP Rotate Keys Orb
+
+This orb can be used to rotate the keys for GCP service accounts, performing
+arbitrary processing after the new key is created but before the old key is
+deleted. This is useful for performing actions such as restarting services to
+pick up the new keys, etc.
+
+## Executors
+
+This orb defines a single default executor that is the `cimg/base:stable`
+docker image. The orb commands require `bash`, `jq`, `aws`, and `gcloud` so any
+image which contains those utilities will work.
+
+## Commands
+
+### rotate-gcp-key
+
+This command rotates the key of the given GCP service account and performs
+arbitrary processing after creating the new key but before deleting the old
+one.
+
+This command requires that authentication to `gcloud` has been performed. See
+the [circleci/gcp-cli](https://circleci.com/developer/orbs/orb/circleci/gcp-cli)
+orb for one way to handle authentication.
+
+The command makes available three environment variables so that the processing
+stage can do things with the keys:
+* `ROTATED_KEY_PATH` - Path containing the exported JSON key file
+* `ROTATED_KEY_ID` - ID of the key that has been created
+* `PREVIOUS_KEY_ID` - ID of the key that is being rotated out
+
+The JSON key file at `ROTATED_KEY_PATH` is deleted after this command finishes.
+
+Parameters:
+* `service-account` - The service account email address to rotate the key of
+* `steps` - The series of steps to perform during key rotation
+
+### rotate-gcp-key-in-aws-ssm
+
+This command is almost identical to `rotate-gcp-key` however it will upload the
+generated key to AWS SSM Parameter Store before performing arbitrary
+processing.
+
+As well as requiring that authentication to `gcloud` has been performed, this
+command also requires that authentication to `aws` has been performed. See the
+[circleci/aws-cli](https://circleci.com/developer/orbs/orb/circleci/aws-cli)
+orb for one method to handle AWS authentication.
+
+Parameters:
+* `service-account` - The service account email address to rotate the key of
+* `steps` - The series of steps to perform during key rotation
+* `ssm-path` - The SSM path to save the updated key in
+
+## Jobs
+
+### rotate-key-redeploy-ecs-service
+
+This job rotates the key of the given GCP service account, uploads the key to
+AWS SSM Parameter Store, and finally forces a redeploy of an AWS ECS service.
+
+Parameters:
+* `aws-access-key-id` - AWS access key id for IAM role
+* `aws-region` - AWS region to operate in
+* `aws-secret-access-key` - AWS secret key for IAM role
+* `ecs-cluster-name` - Name of the ECS cluster containing the service to
+  redeploy during the key rotation process
+* `ecs-service-name` - Name of the service to redeploy during the key rotation
+  process
+* `gcloud-service-key` - Full service key JSON file to connect with
+* `google-compute-region` - The Google compute region to connect with
+* `google-compute-zone` - The Google compute zone to connect with
+* `google-project-id` - The Google project ID to connect with
+* `redeploy-timeout` - Number of seconds to wait for the redeployment to reach
+  steady state
+* `service-account` - The service account email address to rotate the key of
+* `ssm-path` - The SSM path where the service account key is saved
+
+## Limitations
+
+Currently the commands will abort without doing anything if the service account
+has more than key.

--- a/gcp-rotate-keys/orb.yml
+++ b/gcp-rotate-keys/orb.yml
@@ -112,10 +112,10 @@ commands:
                 rm -f "${ROTATED_KEY_PATH}"
 
 jobs:
-  rotate-key-redeploy-fargate-service:
+  rotate-key-redeploy-ecs-service:
     description: >
       Rotates the key of the given GCP service account and rotates an AWS
-      fargate service that is using it.
+      ECS service that is using it.
     executor: default
     parameters:
       aws-access-key-id:
@@ -130,12 +130,12 @@ jobs:
         type: env_var_name
         description: AWS secret key for IAM role
         default: AWS_SECRET_ACCESS_KEY
-      fargate-cluster-name:
+      ecs-cluster-name:
         type: string
         description: >
-          Name of the fargate cluster containing the service to redeploy during
+          Name of the ECS cluster containing the service to redeploy during
           the key rotation process
-      fargate-service-name:
+      ecs-service-name:
         type: string
         description: >
           Name of the service to redeploy during the key rotation process
@@ -178,8 +178,8 @@ jobs:
           ssm-path: << parameter.ssm-path >>
           steps:
             - run:
-                name: Redeploy the fargate service
+                name: Redeploy the ecs service
                 command: |
-                  include scripts/redeploy-fargate.sh
+                  include scripts/redeploy-ecs.sh
 
-                  redeploy_fargate "<< parameter.fargate-cluster-name >>" "<< parameter.fargate-service-name >>" "<< parameter.redeploy-timeout >>"
+                  redeploy_ecs "<< parameter.ecs-cluster-name >>" "<< parameter.ecs-service-name >>" "<< parameter.redeploy-timeout >>"

--- a/gcp-rotate-keys/orb.yml
+++ b/gcp-rotate-keys/orb.yml
@@ -100,9 +100,12 @@ commands:
       - run:
           name: Upload the key to AWS SSM parameter store
           command: |
+            include scripts/delete-key.sh
             include scripts/deploy-file-to-ssm.sh
 
+            trap 'delete_key "<< parameters.service-account >>" "${GENERATED_KEY_ID}"' EXIT
             deploy_file_to_ssm "<< parameters.ssm-path >>" "${GENERATED_KEY_PATH}"
+            trap - EXIT
       - steps: << parameters.steps >>
       - run:
           name: Delete the old key for the service account

--- a/gcp-rotate-keys/orb.yml
+++ b/gcp-rotate-keys/orb.yml
@@ -83,33 +83,30 @@ commands:
       <<: *ssm-path
       <<: *steps
     steps:
-      rotate-gcp-key:
-        service-account: << parameter.service-account >>
-        steps:
-          - run:
-              name: Create a new key for the service account
-              command: |
-                include scripts/generate-key.sh
-                include scripts/get-existing-key.sh
-                include scripts/validate-service-account.sh
+      - run:
+          name: Create a new key for the service account
+          command: |
+            include scripts/generate-key.sh
+            include scripts/get-existing-key.sh
+            include scripts/validate-service-account.sh
 
-                validate_service_account "<< parameter.service-account >>"
-                get_existing_key "<< parameter.service-account >>"
-                generate_key "<< parameter.service-account >>"
-          - run:
-              name: Upload the key to AWS SSM parameter store
-              command: |
-                include scripts/deploy-file-to-ssm.sh
+            validate_service_account "<< parameter.service-account >>"
+            get_existing_key "<< parameter.service-account >>"
+            generate_key "<< parameter.service-account >>"
+      - run:
+          name: Upload the key to AWS SSM parameter store
+          command: |
+            include scripts/deploy-file-to-ssm.sh
 
-                deploy_file_to_ssm "<< parameter.ssm-path >>" "${ROTATED_KEY_PATH}"
-          - steps: << parameters.steps >>
-          - run:
-              name: Delete the old key for the service account
-              command: |
-                include scripts/delete-key.sh
+            deploy_file_to_ssm "<< parameter.ssm-path >>" "${ROTATED_KEY_PATH}"
+      - steps: << parameters.steps >>
+      - run:
+          name: Delete the old key for the service account
+          command: |
+            include scripts/delete-key.sh
 
-                delete_key "<< parameter.service-account >>" "${PREVIOUS_KEY_ID}"
-                rm -f "${ROTATED_KEY_PATH}"
+            delete_key "<< parameter.service-account >>" "${PREVIOUS_KEY_ID}"
+            rm -f "${ROTATED_KEY_PATH}"
 
 jobs:
   rotate-key-redeploy-ecs-service:

--- a/gcp-rotate-keys/orb.yml
+++ b/gcp-rotate-keys/orb.yml
@@ -44,8 +44,8 @@ commands:
       processing after creating the new key but before deleting the old key.
 
       The newly created key is available at a temporary path stored in the
-      environment variable ROTATED_KEY_PATH and the ID is available in the
-      environment variable ROTATED_KEY_ID.
+      environment variable GENERATED_KEY_PATH and the ID is available in the
+      environment variable GENERATED_KEY_ID.
 
       The old key ID is available in the environment variable PREVIOUS_KEY_ID.
     parameters:
@@ -69,7 +69,7 @@ commands:
             include scripts/delete-key.sh
 
             delete_key "<< parameters.service-account >>" "${PREVIOUS_KEY_ID}"
-            rm -f "${ROTATED_KEY_PATH}"
+            rm -f "${GENERATED_KEY_PATH}"
 
   rotate-gcp-key-in-aws-ssm:
     description: >
@@ -98,7 +98,7 @@ commands:
           command: |
             include scripts/deploy-file-to-ssm.sh
 
-            deploy_file_to_ssm "<< parameters.ssm-path >>" "${ROTATED_KEY_PATH}"
+            deploy_file_to_ssm "<< parameters.ssm-path >>" "${GENERATED_KEY_PATH}"
       - steps: << parameters.steps >>
       - run:
           name: Delete the old key for the service account
@@ -106,7 +106,7 @@ commands:
             include scripts/delete-key.sh
 
             delete_key "<< parameters.service-account >>" "${PREVIOUS_KEY_ID}"
-            rm -f "${ROTATED_KEY_PATH}"
+            rm -f "${GENERATED_KEY_PATH}"
 
 jobs:
   rotate-key-redeploy-ecs-service:

--- a/gcp-rotate-keys/orb.yml
+++ b/gcp-rotate-keys/orb.yml
@@ -69,7 +69,11 @@ commands:
             include scripts/delete-key.sh
 
             delete_key "<< parameters.service-account >>" "${PREVIOUS_KEY_ID}"
+      - run:
+          name: Delete the local generated key file
+          command: |
             rm -f "${GENERATED_KEY_PATH}"
+          when: always
 
   rotate-gcp-key-in-aws-ssm:
     description: >
@@ -106,7 +110,11 @@ commands:
             include scripts/delete-key.sh
 
             delete_key "<< parameters.service-account >>" "${PREVIOUS_KEY_ID}"
+      - run:
+          name: Delete the local generated key file
+          command: |
             rm -f "${GENERATED_KEY_PATH}"
+          when: always
 
 jobs:
   rotate-key-redeploy-ecs-service:

--- a/gcp-rotate-keys/orb.yml
+++ b/gcp-rotate-keys/orb.yml
@@ -59,16 +59,16 @@ commands:
             include scripts/get-existing-key.sh
             include scripts/validate-service-account.sh
 
-            validate_service_account "<< parameter.service-account >>"
-            get_existing_key "<< parameter.service-account >>"
-            generate_key "<< parameter.service-account >>"
+            validate_service_account "<< parameters.service-account >>"
+            get_existing_key "<< parameters.service-account >>"
+            generate_key "<< parameters.service-account >>"
       - steps: << parameters.steps >>
       - run:
           name: Delete the old key for the service account
           command: |
             include scripts/delete-key.sh
 
-            delete_key "<< parameter.service-account >>" "${PREVIOUS_KEY_ID}"
+            delete_key "<< parameters.service-account >>" "${PREVIOUS_KEY_ID}"
             rm -f "${ROTATED_KEY_PATH}"
 
   rotate-gcp-key-in-aws-ssm:
@@ -90,22 +90,22 @@ commands:
             include scripts/get-existing-key.sh
             include scripts/validate-service-account.sh
 
-            validate_service_account "<< parameter.service-account >>"
-            get_existing_key "<< parameter.service-account >>"
-            generate_key "<< parameter.service-account >>"
+            validate_service_account "<< parameters.service-account >>"
+            get_existing_key "<< parameters.service-account >>"
+            generate_key "<< parameters.service-account >>"
       - run:
           name: Upload the key to AWS SSM parameter store
           command: |
             include scripts/deploy-file-to-ssm.sh
 
-            deploy_file_to_ssm "<< parameter.ssm-path >>" "${ROTATED_KEY_PATH}"
+            deploy_file_to_ssm "<< parameters.ssm-path >>" "${ROTATED_KEY_PATH}"
       - steps: << parameters.steps >>
       - run:
           name: Delete the old key for the service account
           command: |
             include scripts/delete-key.sh
 
-            delete_key "<< parameter.service-account >>" "${PREVIOUS_KEY_ID}"
+            delete_key "<< parameters.service-account >>" "${PREVIOUS_KEY_ID}"
             rm -f "${ROTATED_KEY_PATH}"
 
 jobs:
@@ -162,21 +162,21 @@ jobs:
     steps:
       - gcp/install
       - gcp/initialize:
-          gcloud-service-key: << parameter.gcloud-service-key >>
-          google-compute-region: << parameter.google-compute-region >>
-          google-compute-zone: << parameter.google-compute-zone >>
-          google-project-id: << parameter.google-project-id >>
+          gcloud-service-key: << parameters.gcloud-service-key >>
+          google-compute-region: << parameters.google-compute-region >>
+          google-compute-zone: << parameters.google-compute-zone >>
+          google-project-id: << parameters.google-project-id >>
       - aws/setup:
-          aws-access-key-id: << parameter.aws-access-key-id >>
-          aws-region: << parameter.aws-region >>
-          aws-secret-access-key: << parameter.aws-secret-access-key >>
+          aws-access-key-id: << parameters.aws-access-key-id >>
+          aws-region: << parameters.aws-region >>
+          aws-secret-access-key: << parameters.aws-secret-access-key >>
       - rotate-gcp-key-in-aws-ssm:
-          service-account: << parameter.service-account >>
-          ssm-path: << parameter.ssm-path >>
+          service-account: << parameters.service-account >>
+          ssm-path: << parameters.ssm-path >>
           steps:
             - run:
                 name: Redeploy the ecs service
                 command: |
                   include scripts/redeploy-ecs.sh
 
-                  redeploy_ecs "<< parameter.ecs-cluster-name >>" "<< parameter.ecs-service-name >>" "<< parameter.redeploy-timeout >>"
+                  redeploy_ecs "<< parameters.ecs-cluster-name >>" "<< parameters.ecs-service-name >>" "<< parameters.redeploy-timeout >>"

--- a/gcp-rotate-keys/orb.yml
+++ b/gcp-rotate-keys/orb.yml
@@ -1,0 +1,185 @@
+version: 2.1
+
+description: >
+  An orb that allows rotating the keys of GCP service accounts and updating
+  corresponding values in AWS SSM Parameter Store.
+
+display:
+  source_url: https://github.com/ovotech/circleci-orbs/tree/master/gcp-rotate-keys
+
+executors:
+  default:
+    description: <
+      This orb requires bash, the AWS and GCP command lines, and the command
+      line utility jq to be installed
+    docker:
+      - image: cimg/base:stable
+
+orbs:
+  aws: circleci/aws-cli@1.4.0
+  gcp: circleci/gcp-cli@2.1.0
+
+aliases:
+  parameters:
+    - &service-account
+      service-account:
+        type: string
+        description: The email address of the service account to rotate keys of
+    - &ssm-path
+      ssm-path:
+        type: string
+        description: The AWS SSM path to save the rotated key to
+    - &steps
+      steps:
+        type: steps
+        description: >
+          Actions to take after generating the new key but before deleting the
+          old one
+        default: []
+
+commands:
+  rotate-gcp-key:
+    description: >
+      Rotates the key of the given GCP service account and performs arbitrary
+      processing after creating the new key but before deleting the old key.
+
+      The newly created key is available at a temporary path stored in the
+      environment variable ROTATED_KEY_PATH and the ID is available in the
+      environment variable ROTATED_KEY_ID.
+
+      The old key ID is available in the environment variable PREVIOUS_KEY_ID.
+    parameters:
+      <<: *service-account
+      <<: *steps
+    steps:
+      - run:
+          name: Create a new key for the service account
+          command: |
+            include scripts/generate-key.sh
+            include scripts/get-existing-key.sh
+            include scripts/validate-service-account.sh
+
+            validate_service_account "<< parameter.service-account >>"
+            get_existing_key "<< parameter.service-account >>"
+            generate_key "<< parameter.service-account >>"
+      - steps: << parameters.steps >>
+      - run:
+          name: Delete the old key for the service account
+          command: |
+            include scripts/delete-key.sh
+
+            delete_key "<< parameter.service-account >>" "${PREVIOUS_KEY_ID}"
+            rm -f "${ROTATED_KEY_PATH}"
+
+  rotate-gcp-key-in-aws-ssm:
+    description: >
+      Rotates the key of the given GCP service account and performs arbitrary
+      processing after creating the new key and uploading it to an AWS SSM
+      parameter, but before deleting the old key.
+
+      Exposes the same environment variables as the rotate-gcp-key command
+    parameters:
+      <<: *service-account
+      <<: *ssm-path
+      <<: *steps
+    steps:
+      rotate-gcp-key:
+        service-account: << parameter.service-account >>
+        steps:
+          - run:
+              name: Create a new key for the service account
+              command: |
+                include scripts/generate-key.sh
+                include scripts/get-existing-key.sh
+                include scripts/validate-service-account.sh
+
+                validate_service_account "<< parameter.service-account >>"
+                get_existing_key "<< parameter.service-account >>"
+                generate_key "<< parameter.service-account >>"
+          - run:
+              name: Upload the key to AWS SSM parameter store
+              command: |
+                include scripts/deploy-file-to-ssm.sh
+
+                deploy_file_to_ssm "<< parameter.ssm-path >>" "${ROTATED_KEY_PATH}"
+          - steps: << parameters.steps >>
+          - run:
+              name: Delete the old key for the service account
+              command: |
+                include scripts/delete-key.sh
+
+                delete_key "<< parameter.service-account >>" "${PREVIOUS_KEY_ID}"
+                rm -f "${ROTATED_KEY_PATH}"
+
+jobs:
+  rotate-key-redeploy-fargate-service:
+    description: >
+      Rotates the key of the given GCP service account and rotates an AWS
+      fargate service that is using it.
+    executor: default
+    parameters:
+      aws-access-key-id:
+        type: env_var_name
+        description: AWS access key id for IAM role
+        default: AWS_ACCESS_KEY_ID
+      aws-region:
+        type: env_var_name
+        description: AWS region to operate in
+        default: AWS_DEFAULT_REGION
+      aws-secret-access-key:
+        type: env_var_name
+        description: AWS secret key for IAM role
+        default: AWS_SECRET_ACCESS_KEY
+      fargate-cluster-name:
+        type: string
+        description: >
+          Name of the fargate cluster containing the service to redeploy during
+          the key rotation process
+      fargate-service-name:
+        type: string
+        description: >
+          Name of the service to redeploy during the key rotation process
+      gcloud-service-key:
+        type: env_var_name
+        description: Full service key JSON file to connect with
+        default: GCLOUD_SERVICE_KEY
+      google-compute-region:
+        type: env_var_name
+        description: The Google compute region to connect with
+        default: GOOGLE_COMPUTE_REGION
+      google-compute-zone:
+        type: env_var_name
+        description: The Google compute zone to connect with
+        default: GOOGLE_COMPUTE_ZONE
+      google-project-id:
+        type: env_var_name
+        description: The Google project ID to connect with
+        default: GOOGLE_PROJECT_ID
+      redeploy-timeout:
+        type: integer
+        description: >
+          Number of seconds to wait for the redeployment to reach steady state
+        default: 300
+      <<: *service-account
+      <<: *ssm-path
+    steps:
+      - gcp/install
+      - gcp/initialize:
+          gcloud-service-key: << parameter.gcloud-service-key >>
+          google-compute-region: << parameter.google-compute-region >>
+          google-compute-zone: << parameter.google-compute-zone >>
+          google-project-id: << parameter.google-project-id >>
+      - aws/setup:
+          aws-access-key-id: << parameter.aws-access-key-id >>
+          aws-region: << parameter.aws-region >>
+          aws-secret-access-key: << parameter.aws-secret-access-key >>
+      - rotate-gcp-key-in-aws-ssm:
+          service-account: << parameter.service-account >>
+          ssm-path: << parameter.ssm-path >>
+          steps:
+            - run:
+                name: Redeploy the fargate service
+                command: |
+                  include scripts/redeploy-fargate.sh
+
+                  redeploy_fargate "<< parameter.fargate-cluster-name >>" "<< parameter.fargate-service-name >>" "<< parameter.redeploy-timeout >>"

--- a/gcp-rotate-keys/orb_version.txt
+++ b/gcp-rotate-keys/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/gcp-rotate-keys@0.0.1
+ovotech/gcp-rotate-keys@1.0.0

--- a/gcp-rotate-keys/orb_version.txt
+++ b/gcp-rotate-keys/orb_version.txt
@@ -1,0 +1,1 @@
+ovotech/gcp-rotate-keys@0.0.1

--- a/gcp-rotate-keys/scripts/delete-key.sh
+++ b/gcp-rotate-keys/scripts/delete-key.sh
@@ -1,0 +1,12 @@
+##
+# Deletes an existing key for a given service account
+# Args:
+#  * $1 - Service Account email address
+#  * $2 - ID of the key to delete
+delete_key() {
+  local _SA="$1"
+  local _KEY="$2"
+
+  echo "Deleting key ID ${_KEY}"
+  gcloud iam service-accounts keys delete "${_KEY}" --iam-account "${_SA}" --quiet
+}

--- a/gcp-rotate-keys/scripts/deploy-file-to-ssm.sh
+++ b/gcp-rotate-keys/scripts/deploy-file-to-ssm.sh
@@ -1,0 +1,12 @@
+##
+# Deploy a key to AWS SSM parameter store
+# Args:
+#  * $1 - Path to deploy to
+#  * $2 - File containing the key
+deploy_file_to_ssm() {
+  local _PATH="$1"
+  local _FILE="$2"
+
+  echo "Deploying to AWS SSM parameter store at ${_PATH}"
+  AWS_PAGER="" aws ssm put-parameter --name="${_PATH}" --type="SecureString" --value="file://${_FILE}" --overwrite
+}

--- a/gcp-rotate-keys/scripts/generate-key.sh
+++ b/gcp-rotate-keys/scripts/generate-key.sh
@@ -1,0 +1,22 @@
+##
+# Generates a key for a given service account. Saves the path where the key
+# is generated to the GENERATED_KEY_PATH environment variable in the $BASH_ENV
+# file. Also saves the generated key ID to the GENERATED_KEY_ID environment
+# variable in the $BASH_ENV file
+# Args:
+#  * $1 - Service Account email address
+generate_key() {
+  local _SA="$1"
+  local GENERATED_KEY_PATH=""
+  local GENERATED_KEY_ID=""
+
+  echo "Generating key"
+  GENERATED_KEY_PATH="$(mktemp).json"
+  GENERATED_KEY_ID=$(
+    gcloud iam service-accounts keys create "${GENERATED_KEY_PATH}" \
+      --iam-account "${_SA}" 2>&1 | grep -Eo '([0-9a-f]{40})'
+  )
+
+  echo "export GENERATED_KEY_ID=${GENERATED_KEY_ID}" >> "${BASH_ENV}"
+  echo "export GENERATED_KEY_PATH=${GENERATED_KEY_PATH}" >> "${BASH_ENV}"
+}

--- a/gcp-rotate-keys/scripts/get-existing-key.sh
+++ b/gcp-rotate-keys/scripts/get-existing-key.sh
@@ -1,0 +1,18 @@
+##
+# Gets the existing key(s) for a given service account and saves the ID of the
+# key into the PREVIOUS_KEY_ID environment variable in the $BASH_ENV file
+# Args:
+#  * $1 - Service Account email address
+get_existing_key() {
+  local _SA="$1"
+  local PREVIOUS_KEY_ID=""
+
+  PREVIOUS_KEY_ID=$(
+    gcloud iam service-accounts keys list \
+      --filter='keyType=USER_MANAGED' \
+      --format='value(name)' \
+      --iam-account "${_SA}"
+  )
+
+  echo "export PREVIOUS_KEY_ID=${PREVIOUS_KEY_ID}" >> "${BASH_ENV}"
+}

--- a/gcp-rotate-keys/scripts/redeploy-ecs.sh
+++ b/gcp-rotate-keys/scripts/redeploy-ecs.sh
@@ -1,10 +1,10 @@
 ##
-# Redeploys a service on fargate to pick up new keys
+# Redeploys a service on ECS to pick up new keys
 # Args:
 #  * $1 - Cluster name
 #  * $2 - Service name
 #  * $3 - Number of seconds to wait for update until aborting
-redeploy_fargate() {
+redeploy_ecs() {
   local _CLUSTER="$1"
   local _SERVICE="$2"
   local _TIMEOUT="$3"

--- a/gcp-rotate-keys/scripts/redeploy-fargate.sh
+++ b/gcp-rotate-keys/scripts/redeploy-fargate.sh
@@ -1,0 +1,42 @@
+##
+# Redeploys a service on fargate to pick up new keys
+# Args:
+#  * $1 - Cluster name
+#  * $2 - Service name
+#  * $3 - Number of seconds to wait for update until aborting
+redeploy_fargate() {
+  local _CLUSTER="$1"
+  local _SERVICE="$2"
+  local _TIMEOUT="$3"
+
+  echo "Redeploying ${_SERVICE} on cluster ${_CLUSTER}"
+  AWS_PAGER="" aws ecs update-service --cluster "${_CLUSTER}" --service "${_SERVICE}" --force-new-deployment
+
+  ##
+  # Wait to reach a steady state
+  local _START=""
+  local _UPDATED="0"
+  _START="$(date +%s)"
+
+  while [[ "${_UPDATED}" -lt "1" ]]; do
+    if [[ "$(date +%s)" -gt $((_START + _TIMEOUT)) ]]; then
+      echo "Timed out while waiting for ${_SERVICE} to reach steady state"
+      return 1
+    fi
+
+    sleep 5
+
+    _UPDATED=$(
+      AWS_PAGER="" aws ecs describe-services --cluster "${_CLUSTER}" --service "${_SERVICE}" \
+        | jq --arg now "${_START}" --arg name "${_SERVICE}" \
+          '.services[]
+          | select(.serviceName == $name).events
+          | map(select(
+            (.createdAt | sub("\\.[0-9]+\\+00:00"; "Z") | fromdate >= ($now | tonumber))
+            and
+            (.message | contains("reached a steady state"))
+          ))
+          | length'
+    )
+  done
+}

--- a/gcp-rotate-keys/scripts/validate-service-account.sh
+++ b/gcp-rotate-keys/scripts/validate-service-account.sh
@@ -1,0 +1,23 @@
+##
+# Validates the service account
+# Args:
+#  * $1 - Email of the service account to validate
+validate_service_account() {
+  local _SA="$1"
+
+  if [[ "${_SA}" == "" ]]; then
+    echo "Service account parameter is missing"
+    exit 1
+  fi
+
+  if ! (gcloud iam service-accounts list --filter "email=${_SA}" | grep "${_SA}" >/dev/null 2>&1); then
+    echo "Could not find service account ${_SA}"
+    exit 1
+  fi
+
+  _KC=$(gcloud iam service-accounts keys list --filter='keyType=USER_MANAGED' --format='json' --iam-account "${_SA}" | jq '. | length')
+  if [[ "${_KC}" -ne "1" ]]; then
+    echo "Service account has ${_KC} keys. Unable to rotate"
+    exit 1
+  fi
+}


### PR DESCRIPTION
This PR adds a new orb to the repository called `gcp-rotate-keys`. It is designed to help teams rotate their GCP service account credentials.

In my team, our use case involves adding the new key to SSM and redeploying a Fargate service before deleting the old key, in order to prevent any downtime. We were unable to fulfil this requirement with existing tools (e.g. the cloud key rotator) so I have written an orb that is hopefully re-usable by others as well.

The orb has two commands - `rotate-gcp-key` which takes a series of steps to perform actions after creating the new key but before deleting the old one, and `rotate-gcp-key-in-aws-ssm` which will upload the key in AWS SSM Parameter Store before running the series of steps.

It also includes a single job - `rotate-key-redeploy-ecs-service` which implements our use case of redeploying a service on Fargate during the key rotation to pick up the new key.