### PR TITLE
Pin Clair Scanner to golang:1.15

### DIFF
--- a/clair-scanner/executor/Dockerfile
+++ b/clair-scanner/executor/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest as build
+FROM golang:1.15-buster as build
 
 RUN apt-get update && apt-get install -y \
     git \


### PR DESCRIPTION
This PR pins the base image in the clair scanner Dockerfile to `golang:1.15` instead of `golang:latest`. 1.16 was released a couple of days ago which seems to be breaking the build.