### PR TITLE
Add chdir to plan out path

### DIFF
--- a/terraform/apply.sh
+++ b/terraform/apply.sh
@@ -22,12 +22,12 @@ function update_status() {
 }
 
 function apply() {
-    plan_path="plan.out"
-    if terraform -help | grep -e "-chdir" >/dev/null && "<< parameters.use_chdir >>" == "true"; then
-        plan_path="${module_path}/${plan_path}"
-    fi
     set +e
-    terraform apply -input=false -no-color -auto-approve -lock-timeout=300s "${plan_path}" | $TFMASK
+    # We're using chdir here but not using $module_path at the end deliberately. This is
+    # because when running "terraform init $module_path", the .terraform directory is created in
+    # the working directory. When running "terraform -chdir=blah init", the .terraform
+    # directory is created in blah, so the terraform apply also needs to be run from blah with chdir.
+    terraform apply "${chdir}" -input=false -no-color -auto-approve -lock-timeout=300s plan.out | $TFMASK
     local TF_EXIT=${PIPESTATUS[0]}
     set -e
 

--- a/terraform/apply.sh
+++ b/terraform/apply.sh
@@ -22,8 +22,12 @@ function update_status() {
 }
 
 function apply() {
+    plan_path="plan.out"
+    if terraform -help | grep -e "-chdir" >/dev/null && "<< parameters.use_chdir >>" == "true"; then
+        plan_path="${module_path}/${plan_path}"
+    fi
     set +e
-    terraform apply -input=false -no-color -auto-approve -lock-timeout=300s plan.out | $TFMASK
+    terraform apply -input=false -no-color -auto-approve -lock-timeout=300s "${plan_path}" | $TFMASK
     local TF_EXIT=${PIPESTATUS[0]}
     set -e
 

--- a/terraform/apply.sh
+++ b/terraform/apply.sh
@@ -27,7 +27,7 @@ function apply() {
     # because when running "terraform init $module_path", the .terraform directory is created in
     # the working directory. When running "terraform -chdir=blah init", the .terraform
     # directory is created in blah, so the terraform apply also needs to be run from blah with chdir.
-    terraform apply "${chdir}" -input=false -no-color -auto-approve -lock-timeout=300s plan.out | $TFMASK
+    terraform apply $chdir -input=false -no-color -auto-approve -lock-timeout=300s plan.out | $TFMASK
     local TF_EXIT=${PIPESTATUS[0]}
     set -e
 

--- a/terraform/apply.sh
+++ b/terraform/apply.sh
@@ -27,7 +27,7 @@ function apply() {
     # because when running "terraform init $module_path", the .terraform directory is created in
     # the working directory. When running "terraform -chdir=blah init", the .terraform
     # directory is created in blah, so the terraform apply also needs to be run from blah with chdir.
-    terraform apply $chdir -input=false -no-color -auto-approve -lock-timeout=300s plan.out | $TFMASK
+    terraform $chdir apply -input=false -no-color -auto-approve -lock-timeout=300s plan.out | $TFMASK
     local TF_EXIT=${PIPESTATUS[0]}
     set -e
 


### PR DESCRIPTION
Adds the `$chdir` variable to tf apply

If the user has chdir functionality enabled, the `plan.out` from the preceding tf plan would have been created in the `$chdir` directory (so currently all tf apply operations with chdir in the orb will be failing after the apply is done).

Users without chdir func enabled should be uneffected.

Tested the devorb on both paths (chdir enabled/disabled).