### PR TITLE
[GCP Rotate Keys] Decode base64 encoded keys if necessary

### DIFF
--- a/gcp-rotate-keys/orb.yml
+++ b/gcp-rotate-keys/orb.yml
@@ -171,6 +171,12 @@ jobs:
       <<: *service-account
       <<: *ssm-path
     steps:
+      - run:
+          name: Prepare the GCP service account key
+          command: |
+            include scripts/maybe-decode.sh
+
+            echo "export << parameters.gcloud-service-key >>='"$(maybe_decode "$(printenv << parameters.gcloud-service-key >>)")"'" >> $BASH_ENV
       - gcp/install
       - gcp/initialize:
           gcloud-service-key: << parameters.gcloud-service-key >>

--- a/gcp-rotate-keys/orb_version.txt
+++ b/gcp-rotate-keys/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/gcp-rotate-keys@1.0.0
+ovotech/gcp-rotate-keys@1.0.1

--- a/gcp-rotate-keys/scripts/maybe-decode.sh
+++ b/gcp-rotate-keys/scripts/maybe-decode.sh
@@ -1,0 +1,17 @@
+##
+# If the input appears to be a valid base64 string then decode it, otherwise
+# return it as is
+# Args:
+#  * $1 - Potentially base64 encoded string
+maybe_decode () {
+  local _VAL=${1}
+
+  # Test that the value appears to be a base64 encoded string. If not, return
+  # the value immediately
+  if ! (grep -E '^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$' <<< "${_VAL}" >/dev/null 2>&1); then
+    echo "${_VAL}"
+    return 0
+  fi
+
+  echo "${_VAL}" | base64 -d
+}


### PR DESCRIPTION
This PR updates the `rotate-key-redeploy-ecs-service` job in the `gcp-rotate-keys` orb to be able to decode the GCP service account key if it has been base64 encoded (for example, if it has been rotated by cloud key rotator).