### PR TITLE
Copy queue orb

### DIFF
--- a/circleci-queue/README.md
+++ b/circleci-queue/README.md
@@ -5,34 +5,15 @@
 CircleCI Orb to limit workflow concurrency.
 
 Why? Some jobs (typically deployments) need to run sequentially and not parallel, but also run to completion. So CircleCI's native `auto-cancel` is not quite the right fit.
-See https://github.com/eddiewebb/circleci-challenge as an example using blue/green cloud foundry deployments.
+See https://github.com/ovotech/circleci-challenge as an example using blue/green cloud foundry deployments.
 
 ## Basic Usage
 
 This adds concurrency limits by ensuring any jobs with this step will only continue once no previous builds are running. It supports a single argument of how many minutes to wait before aborting itself and it requires a single Environment Variable `CIRCLECI_API_KEY` - which can be created in [account settings](https://circleci.com/account/api).
 
-## Screenshots / Examples
-
-Suppose we have a workflow take takes a little while to run. Normally the build (#18) will run immediately, with no queuing.
-![no queuing if only active build](assets/build_noqueue.png)
-
-Someone else on the team makes another commit, since the first build (#18) is still running, it will queue build #19.
-![no queuing if only active build](assets/build_queue2.png)
-
-It's late afternoon, everyone is pushing their commits in to ensure they are good before they leave for the day. Build #20 also queues.
-![no queuing if only active build](assets/build_queued.png)
-
-Meanwhile, build #19 is now allowed to move forward since build #18 finished.
-
-![no queuing if only active build](assets/build_progressed.png)
-
-Oh No! Since `1 minute` is abnormally long for things to be queued, build #20 aborts itself, letting build #19 finish uninterrupted.
-
-![no queuing if only active build](assets/build_aborted.png)
-
 # Setup
 
-See https://circleci.com/orbs/registry/orb/eddiewebb/queue#usage-examples for current examples
+See https://circleci.com/orbs/registry/orb/ovotech/queue#usage-examples for current examples
 
 ## Note
 

--- a/circleci-queue/README.md
+++ b/circleci-queue/README.md
@@ -1,0 +1,39 @@
+# CircleCI Concurrency Control Orb
+
+> :information_source: Copy of [this repo](https://github.com/eddiewebb/circleci-queue) at [this commit](https://github.com/eddiewebb/circleci-queue/tree/9e7fc054183e0bcd891f9258d2661bd9223ffe06)
+
+CircleCI Orb to limit workflow concurrency.
+
+Why? Some jobs (typically deployments) need to run sequentially and not parallel, but also run to completion. So CircleCI's native `auto-cancel` is not quite the right fit.
+See https://github.com/eddiewebb/circleci-challenge as an example using blue/green cloud foundry deployments.
+
+## Basic Usage
+
+This adds concurrency limits by ensuring any jobs with this step will only continue once no previous builds are running. It supports a single argument of how many minutes to wait before aborting itself and it requires a single Environment Variable `CIRCLECI_API_KEY` - which can be created in [account settings](https://circleci.com/account/api).
+
+## Screenshots / Examples
+
+Suppose we have a workflow take takes a little while to run. Normally the build (#18) will run immediately, with no queuing.
+![no queuing if only active build](assets/build_noqueue.png)
+
+Someone else on the team makes another commit, since the first build (#18) is still running, it will queue build #19.
+![no queuing if only active build](assets/build_queue2.png)
+
+It's late afternoon, everyone is pushing their commits in to ensure they are good before they leave for the day. Build #20 also queues.
+![no queuing if only active build](assets/build_queued.png)
+
+Meanwhile, build #19 is now allowed to move forward since build #18 finished.
+
+![no queuing if only active build](assets/build_progressed.png)
+
+Oh No! Since `1 minute` is abnormally long for things to be queued, build #20 aborts itself, letting build #19 finish uninterrupted.
+
+![no queuing if only active build](assets/build_aborted.png)
+
+# Setup
+
+See https://circleci.com/orbs/registry/orb/eddiewebb/queue#usage-examples for current examples
+
+## Note
+
+Queueing is not supported on forked repos. If a queue from a fork happens the queue will immediately exit and the next step of the job will begin.

--- a/circleci-queue/src/@orb.yml
+++ b/circleci-queue/src/@orb.yml
@@ -1,0 +1,57 @@
+version: 2.1
+description: |
+  Allows jobs or entire workflows to be queued to ensure they run in serial.  
+  This is ideal for deployments or other activities that must not run concurrently.
+  May optionaly consider branch-level isolation if unique branches should run concurrently. 
+  This orb requires the project to have an API key in order to query build states.
+
+examples:
+  queue_workflow:
+    description: Used typically as first job and will queue until no previous workflows are running
+    usage:
+      version: 2.1
+      orbs:
+        queue: ovotech/queue@1.5.0
+
+      workflows:
+        build_deploy:
+          jobs:
+            - queue/block_workflow:
+                time: "10" # max wait, in minutes (default 10)
+                only-on-branch: master # restrict queueing to a specific branch (default *)
+            - some_other_job:
+                requires:
+                  - queue/block_workflow
+
+  single_concurrency_job:
+    description: |
+      Used to ensure that a only single job (deploy) is not run concurrently. 
+      By default will only queue if the same job from previous worfklows is running on the same branch. 
+      This allows safe jobs like build/test to overlap, minimizing overall queue times.
+    usage:
+      version: 2.1
+      orbs:
+        queue: ovotech/queue@1.5.0
+
+      workflows:
+        build_deploy:
+          jobs:
+            - build
+            - deploy:
+                requires:
+                  - build
+      jobs:
+        build:
+          docker:
+            - image: circleci/node:10
+          steps:
+            - run: echo "This job can overlap"
+
+        deploy:
+          docker:
+            - image: circleci/node:10
+          steps:
+            - queue/until_front_of_line:
+                time: "10" # max wait, in minutes (default 10)
+                only-on-branch: master # restrict queueing to a specific branch (default *)
+            - run: echo "This job will not overlap"

--- a/circleci-queue/src/commands/until_front_of_line.yml
+++ b/circleci-queue/src/commands/until_front_of_line.yml
@@ -1,0 +1,208 @@
+parameters:
+  consider-branch:
+    type: boolean
+    default: true
+    description: "Should we only consider jobs running on the same branch?"
+  block-workflow:
+    type: boolean
+    # this is false at COMMAND level as intention is to only block CURRENT job.
+    default: false
+    description: "If true, this job will block until no other workflows with an earlier timestamp are running. Typically used as first job."
+  time:
+    type: string
+    default: "10"
+    description: "How long to wait before giving up."
+  dont-quit:
+    type: boolean
+    default: false
+    description: "Quitting is for losers. Force job through once time expires instead of failing."
+  only-on-branch:
+    type: string
+    default: "*"
+    description: "Only queue on specified branch"
+  vcs-type:
+    type: string
+    default: "github"
+    description: "Override VCS to 'bitbucket' if needed."
+  confidence:
+    type: string
+    default: "1"
+    description: "Due to scarce API, we need to requery the recent jobs list to ensure we're not just in a pending state for previous jobs.  This number indicates the threhold for API returning no previous pending jobs. Default is a single confirmation."
+  circleci-api-key:
+    type: env_var_name
+    default: CIRCLECI_API_KEY
+    description: "In case you use a different Environment Variable Name than CIRCLECI_API_KEY, supply it here."
+steps:
+  - run:
+      name: Queue Until Front of Line
+      command: |
+
+        load_variables(){
+          # just confirm our required variables are present
+          : ${CIRCLE_BUILD_NUM:?"Required Env Variable not found!"}
+          : ${CIRCLE_PROJECT_USERNAME:?"Required Env Variable not found!"}
+          : ${CIRCLE_PROJECT_REPONAME:?"Required Env Variable not found!"}
+          : ${CIRCLE_REPOSITORY_URL:?"Required Env Variable not found!"}
+          : ${CIRCLE_JOB:?"Required Env Variable not found!"}
+          # Only needed for private projects
+          if [ -z "${<< parameters.circleci-api-key >>}" ]; then
+            echo "<< parameters.circleci-api-key >> not set. Private projects will be inaccessible."
+          fi
+          VCS_TYPE="<<parameters.vcs-type>>"
+        }
+
+
+
+
+
+        fetch_filtered_active_builds(){
+          if [ "<<parameters.consider-branch>>" != "true" ];then
+            echo "Orb parameter 'consider-branch' is false, will block previous builds on any branch."
+            jobs_api_url_template="https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}?circle-token=${<< parameters.circleci-api-key >>}&filter=running"
+          else
+            echo "Only blocking execution if running previous jobs on branch: ${CIRCLE_BRANCH}"
+            : ${CIRCLE_BRANCH:?"Required Env Variable not found!"}
+            jobs_api_url_template="https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/tree/${CIRCLE_BRANCH}?circle-token=${<< parameters.circleci-api-key >>}&filter=running"
+          fi
+
+          if [ ! -z $TESTING_MOCK_RESPONSE ] && [ -f $TESTING_MOCK_RESPONSE ];then
+            echo "Using test mock response"
+            cat $TESTING_MOCK_RESPONSE > /tmp/jobstatus.json
+          else
+            echo "Attempting to access CircleCI api. If the build process fails after this step, ensure your << parameters.circleci-api-key >> is set."
+            curl -f -s $jobs_api_url_template > /tmp/jobstatus.json
+            echo "API access successful"
+          fi
+        }
+
+        fetch_active_workflows(){
+          cp /tmp/jobstatus.json /tmp/augmented_jobstatus.json
+          for workflow in `jq -r ".[] | .workflows.workflow_id" /tmp/augmented_jobstatus.json | uniq`
+          do
+            echo "Checking time of workflow: ${workflow}"
+            workflow_file=/tmp/workflow-${workflow}.json
+            if [ ! -z $TESTING_MOCK_WORKFLOW_RESPONSES ] && [ -f $TESTING_MOCK_WORKFLOW_RESPONSES/${workflow}.json ]; then
+              echo "Using test mock workflow response"
+              cat $TESTING_MOCK_WORKFLOW_RESPONSES/${workflow}.json > ${workflow_file}
+            else
+              curl -f -s "https://circleci.com/api/v2/workflow/${workflow}?circle-token=${<< parameters.circleci-api-key >>}" > ${workflow_file}
+            fi
+            created_at=`jq -r '.created_at' ${workflow_file}`
+            echo "Workflow was created at: ${created_at}"
+            cat /tmp/augmented_jobstatus.json | jq --arg created_at "${created_at}" --arg workflow "${workflow}" '(.[] | select(.workflows.workflow_id == $workflow) | .workflows) |= . + {created_at:$created_at}' > /tmp/augmented_jobstatus-${workflow}.json
+            #DEBUG echo "new augmented_jobstatus:"
+            #DEBUG cat /tmp/augmented_jobstatus-${workflow}.json
+            mv /tmp/augmented_jobstatus-${workflow}.json /tmp/augmented_jobstatus.json
+          done
+        }
+
+        update_comparables(){     
+          fetch_filtered_active_builds
+
+          fetch_active_workflows
+
+          load_current_workflow_values
+
+          # falsey parameters are empty strings, so always compare against 'true' 
+          if [ "<<parameters.block-workflow>>" = "true" ] ;then
+            echo "Orb parameter block-workflow is true."
+            echo "This job will block until no previous workflows have *any* jobs running."
+            oldest_running_build_num=`jq 'sort_by(.workflows.created_at)| .[0].build_num' /tmp/augmented_jobstatus.json`
+            oldest_commit_time=`jq 'sort_by(.workflows.created_at)| .[0].workflows.created_at' /tmp/augmented_jobstatus.json`
+          else
+            echo "Orb parameter block-workflow is false."
+            echo "Only blocking execution if running previous jobs matching this job: ${CIRCLE_JOB}"
+            oldest_running_build_num=`jq ". | map(select(.build_parameters.CIRCLE_JOB==\"${CIRCLE_JOB}\")) | sort_by(.workflows.created_at)|  .[0].build_num" /tmp/augmented_jobstatus.json`
+            oldest_commit_time=`jq ". | map(select(.build_parameters.CIRCLE_JOB==\"${CIRCLE_JOB}\")) | sort_by(.workflows.created_at)|  .[0].workflows.created_at" /tmp/augmented_jobstatus.json`
+          fi
+          echo "Oldest job: $oldest_running_build_num"
+          if [ -z $oldest_commit_time ];then
+            echo "API Call for existing jobs failed, failing this build.  Please check API token"
+            echo "All running jobs:"
+            cat /tmp/jobstatus.json || exit 0
+            echo "All running jobs with created_at:"
+            cat /tmp/augmented_jobstatus.json || exit 0
+            echo "All worfklow details."
+            cat /tmp/workflow-*.json
+            exit 1
+          fi
+        }
+
+        load_current_workflow_values(){
+           my_commit_time=`jq '.[] | select( .build_num == '"${CIRCLE_BUILD_NUM}"').workflows.created_at' /tmp/augmented_jobstatus.json`
+        }
+
+        cancel_current_build(){
+          echo "Cancelleing build ${CIRCLE_BUILD_NUM}"
+          cancel_api_url_template="https://circleci.com/api/v1.1/project/${VCS_TYPE}/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/${CIRCLE_BUILD_NUM}/cancel?circle-token=${<< parameters.circleci-api-key >>}"
+          curl -s -X POST $cancel_api_url_template > /dev/null
+        }
+
+
+
+        #
+        # We can skip a few use cases without calling API
+        #
+        if [ ! -z "$CIRCLE_PR_REPONAME" ]; then
+          echo "Queueing on forks is not supported. Skipping queue..."
+          # It's important that we not fail here because it could cause issues on the main repo's branch
+          exit 0
+        fi
+        if [ "<<parameters.only-on-branch>>" = "*" ] || [ "<<parameters.only-on-branch>>" = "${CIRCLE_BRANCH}" ]; then
+          echo "${CIRCLE_BRANCH} queueable"
+        else
+          echo "Queueing only happens on <<parameters.only-on-branch>> branch, skipping queue"
+          exit 0
+        fi
+
+        #
+        # Set values that wont change while we wait
+        # 
+        load_variables
+        max_time=<<parameters.time>>
+        echo "This build will block until all previous builds complete."
+        echo "Max Queue Time: ${max_time} minutes."
+        wait_time=0
+        loop_time=11
+        max_time_seconds=$((max_time * 60))
+
+        #
+        # Queue Loop
+        #
+        confidence=0
+        while true; do
+          update_comparables
+          echo "This Workflow Timestamp: $my_commit_time"
+          echo "Oldest Workflow Timestamp: $oldest_commit_time"
+          if [[ "$oldest_commit_time" > "$my_commit_time" ]] || [[ "$oldest_commit_time" = "$my_commit_time" ]] ; then
+            # API returns Y-M-D HH:MM (with 24 hour clock) so alphabetical string compare is accurate to timestamp compare as well
+            # recent-jobs API does not include pending, so it is posisble we queried in between a workfow transition, and we;re NOT really front of line.
+            if [ $confidence -lt <<parameters.confidence>> ];then
+              # To grow confidence, we check again with a delay.
+              confidence=$((confidence+1))
+              echo "API shows no previous jobs/workflows, but it is possible a previous workflow has pending jobs not yet visible in API."
+              echo "Rerunning check ${confidence}/<<parameters.confidence>>"
+            else
+              echo "Front of the line, WooHoo!, Build continuing"
+              break
+            fi
+          else
+            echo "This build (${CIRCLE_BUILD_NUM}) is queued, waiting for build number (${oldest_running_build_num}) to complete."
+            echo "Total Queue time: ${wait_time} seconds."
+          fi
+
+          if [ $wait_time -ge $max_time_seconds ]; then
+            echo "Max wait time exceeded, considering response."
+            if [ "<<parameters.dont-quit>>" == "true" ];then
+              echo "Orb parameter dont-quit is set to true, letting this job proceed!"
+              exit 0
+            else
+              cancel_current_build
+              sleep 10 # wait for API to cancel this job, rather than showing as failure
+              exit 1 # but just in case, fail job
+            fi
+          fi
+
+          sleep $loop_time
+          wait_time=$(( loop_time + wait_time ))
+        done

--- a/circleci-queue/src/jobs/block_workflow.yml
+++ b/circleci-queue/src/jobs/block_workflow.yml
@@ -1,0 +1,48 @@
+parameters:
+  consider-branch:
+    type: boolean
+    default: true
+    description: "Should we only consider jobs running on the same branch?"
+  block-workflow:
+    type: boolean
+    # this is true at JOB level as intention is to block workflow
+    default: true
+    description: "If true, this job will block until no other workflows with an earlier timestamp are running. Typically used as first job."
+  time:
+    type: string
+    default: "10"
+    description: "How many minutes to wait before giving up."
+  dont-quit:
+    type: boolean
+    default: false
+    description: "Quiting is for losers. Force job through once time expires instead of failing."
+  only-on-branch:
+    type: string
+    default: "*"
+    description: "Only queue on specified branch. Default is to enforce serialization on all branches."
+  vcs-type:
+    type: string
+    default: "github"
+    description: "Override VCS to 'bitbucket' if needed."
+  confidence:
+    type: string
+    default: "1"
+    description: "Due to scarce API, we need to requery the recent jobs list to ensure we're not just in a pending state for previous jobs.  This number indicates the threhold for API returning no previous pending jobs. Default is a single confirmation."
+  circleci-api-key:
+    type: env_var_name
+    default: CIRCLECI_API_KEY
+    description: "In case you use a different Environment Variable Name than CIRCLECI_API_KEY, supply it here."
+
+docker:
+  - image: cimg/base:stable
+resource_class: small
+steps:
+  - until_front_of_line:
+      consider-branch: <<parameters.consider-branch>>
+      block-workflow: <<parameters.block-workflow>>
+      time: <<parameters.time>>
+      dont-quit: <<parameters.dont-quit>>
+      only-on-branch: <<parameters.only-on-branch>>
+      vcs-type: <<parameters.vcs-type>>
+      confidence: <<parameters.confidence>>
+      circleci-api-key: <<parameters.circleci-api-key>>

--- a/circleci-queue/src/orb_version.txt
+++ b/circleci-queue/src/orb_version.txt
@@ -1,0 +1,1 @@
+ovotech/queue@1.5.0


### PR DESCRIPTION
As noted in the README this is a copy of https://github.com/eddiewebb/circleci-queue, I would love to use this orb as part of a workflow to enforce that certain jobs cannot run concurrently, since at the moment this is on each developer to remember and forgetting can have quite disastrous effects. As such I've attempted to create a fork here.

I'm not sure that the CI setup is exactly the same in this repo as in the original repo so I might need help deploying a "dev" version of the orb to make sure it works before publishing anything. Let me know if there are any questions 😄 