### PR TITLE
SBT-1062 - Create orb allowing service updates through kustomize

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,4 +162,4 @@ workflows:
                 - jaws-journey-deploy
                 - oot-deploy
                 - gcp-rotate-keys
-
+                - sbt-deploy

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,4 @@
 /ssh-proxy/               @ovotech/orion-security-engineering
 /jaws-journey-deploy      @ovotech/jaws-library-maintainers
 /oot-deploy/              @ovotech/orion-ops-tooling
+/sbt-deploy/              @ovotech/smart-bookings

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ any changes to the orb.
  - [ovotech/clojure](clojure) - test, scan and package Clojure projects built using Leiningen. 
  - [ovotech/oot-eks](oot-eks) - deploy services to EKS, OOT-style. 
  - [ovotech/oot-deploy](oot-deploy) - deploy services via Argo, OOT-style. 
+ - [ovotech/sbt-deploy](sbt-deploy) - Deploy services via Argo, using Kustomize. 
  
  Other orbs in the ovotech namespace:
  - [ovotech/shipit@1](https://github.com/ovotech/pe-orbs/tree/master/shipit) - Run shipit and record deployments to https://shipit.ovotech.org.uk.

--- a/sbt-deploy/README.md
+++ b/sbt-deploy/README.md
@@ -1,6 +1,4 @@
-SBT Deploy Orb
-
-=========
+# SBT Deploy Orb
 
 Allows automatic deployment of services via a job which updates a specified gitops repo with the latest service image tags.
 
@@ -8,21 +6,23 @@ Requires the K8s cluster to be configured with Argo and Kustomize.
 
 ## Prerequisites
 
-- Deploy key with push rights to the gitops repo needs to be added to "Additional SSH keys" in consuming CircleCI project.
+- Github deploy key with push rights to the gitops repo needs to be added to the `Additional SSH keys` setting in consuming CircleCI project.
   - The host name should be "github.com".
 
 ## Parameters
 
-- environment [required]
-- service-name [required]
-- service-image-new-name [required]
-- service-image-current-name [default: `SERVICE_IMAGE_NAME`]
-- service-image-new-tag [default: ${CIRCLE_SHA1}]
-- gitops-ssh-key-fingerprint [required]
-- gitops-repo [default: `git@github.com:ovotech/smart-bookings-environments.git`]
-- gitops-username [default: `SBT CircleCI User`]
-- gitops-email [default: `circleci@sme-circleci.ovotech.org.uk`]
-- gitops_overlay_path [default: `overlays/non-prod`]
+| Parameter                  | Required | Default              | Description                             |
+| -------------------------- | -------- | -------------------- | --------------------------------------- |
+| environment                | Yes      | -                    | Which env to deploy within              |
+| service-name               | Yes      | -                    | User readable service name              |
+| service-image-new-name     | Yes      | -                    | Image URI excluding tag                 |
+| service-image-new-tag      | Yes      | -                    | Tag of image to deploy                  |
+| gitops-ssh-key-fingerprint | Yes      | -                    | SSH key to allow gitops repo update     |
+| gitops-repo                | Yes      | -                    | Gitops repository URI                   |
+| gitops-username            | Yes      | -                    | Username to associate with git actions  |
+| gitops-email               | Yes      | -                    | Email to associate with git actions     |
+| gitops_overlay_path        | Yes      | -                    | Path to kustomize overlay to be updated |
+| service-image-current-name | No       | `SERVICE_IMAGE_NAME` | Placeholder image name text in manifest |
 
 ## Example Usage
 
@@ -35,10 +35,13 @@ jobs:
     executor: ???
     steps:
       - sbt-deploy/deploy-service:
-          environment: non-prod
-          service-name: public-api-bookings
-          service-image-new-name: XXXXXX.dkr.ecr.eu-west-1.amazonaws.com/public-api-bookings
-          service-image-new-tag: 1.23.4
-          gitops-ssh-key-fingerprint: "xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx"
-          gitops_overlay_path: overlays/non-prod
+        environment: non-prod
+        service-name: public-api-bookings
+        service-image-new-name: XXXXXX.dkr.ecr.eu-west-1.amazonaws.com/public-api-bookings
+        service-image-new-tag: 1.23.4
+        gitops-ssh-key-fingerprint: "xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx"
+        gitops-repo: git@github.com:ovotech/placeholder-repo.git
+        gitops-username: CircleCI deploy bot
+        gitops-email: deploy-bot@circleci.ovotech.org.uk
+        gitops_overlay_path: overlays/non-prod
 ```

--- a/sbt-deploy/README.md
+++ b/sbt-deploy/README.md
@@ -1,0 +1,44 @@
+SBT Deploy Orb
+
+=========
+
+Allows automatic deployment of services via a job which updates a specified gitops repo with the latest service image tags.
+
+Requires the K8s cluster to be configured with Argo and Kustomize.
+
+## Prerequisites
+
+- Deploy key with push rights to the gitops repo needs to be added to "Additional SSH keys" in consuming CircleCI project.
+  - The host name should be "github.com".
+
+## Parameters
+
+- environment [required]
+- service-name [required]
+- service-image-new-name [required]
+- service-image-current-name [default: `SERVICE_IMAGE_NAME`]
+- service-image-new-tag [default: ${CIRCLE_SHA1}]
+- gitops-ssh-key-fingerprint [required]
+- gitops-repo [default: `git@github.com:ovotech/smart-bookings-environments.git`]
+- gitops-username [default: `SBT CircleCI User`]
+- gitops-email [default: `circleci@sme-circleci.ovotech.org.uk`]
+- gitops_overlay_path [default: `overlays/non-prod`]
+
+## Example Usage
+
+```yaml
+orbs:
+  sbt-deploy: ovotech/sbt-deploy@0.1.0
+
+jobs:
+  deploy-to-uat:
+    executor: ???
+    steps:
+      - sbt-deploy/deploy-service:
+          environment: non-prod
+          service-name: public-api-bookings
+          service-image-new-name: XXXXXX.dkr.ecr.eu-west-1.amazonaws.com/public-api-bookings
+          service-image-new-tag: 1.23.4
+          gitops-ssh-key-fingerprint: "xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx"
+          gitops_overlay_path: overlays/non-prod
+```

--- a/sbt-deploy/README.md
+++ b/sbt-deploy/README.md
@@ -11,18 +11,18 @@ Requires the K8s cluster to be configured with Argo and Kustomize.
 
 ## Parameters
 
-| Parameter                  | Required | Default              | Description                             |
-| -------------------------- | -------- | -------------------- | --------------------------------------- |
-| environment                | Yes      | -                    | Which env to deploy within              |
-| service-name               | Yes      | -                    | User readable service name              |
-| service-image-new-name     | Yes      | -                    | Image URI excluding tag                 |
-| service-image-new-tag      | Yes      | -                    | Tag of image to deploy                  |
-| gitops-ssh-key-fingerprint | Yes      | -                    | SSH key to allow gitops repo update     |
-| gitops-repo                | Yes      | -                    | Gitops repository URI                   |
-| gitops-username            | Yes      | -                    | Username to associate with git actions  |
-| gitops-email               | Yes      | -                    | Email to associate with git actions     |
-| gitops_overlay_path        | Yes      | -                    | Path to kustomize overlay to be updated |
-| service-image-current-name | No       | `SERVICE_IMAGE_NAME` | Placeholder image name text in manifest |
+| Parameter                  | Required |       Default        | Description                             |
+| -------------------------- | :------: | :------------------: | --------------------------------------- |
+| environment                |   Yes    |          -           | Which env to deploy within              |
+| service-name               |   Yes    |          -           | User readable service name              |
+| service-image-new-name     |   Yes    |          -           | Image URI excluding tag                 |
+| service-image-new-tag      |   Yes    |          -           | Tag of image to deploy                  |
+| gitops-ssh-key-fingerprint |   Yes    |          -           | SSH key to allow gitops repo update     |
+| gitops-repo                |   Yes    |          -           | Gitops repository URI                   |
+| gitops-username            |   Yes    |          -           | Username to associate with git actions  |
+| gitops-email               |   Yes    |          -           | Email to associate with git actions     |
+| gitops_overlay_path        |   Yes    |          -           | Path to kustomize overlay to be updated |
+| service-image-current-name |    No    | `SERVICE_IMAGE_NAME` | Placeholder image name text in manifest |
 
 ## Example Usage
 
@@ -32,16 +32,17 @@ orbs:
 
 jobs:
   deploy-to-uat:
-    executor: ???
+    machine:
+      image: ubuntu-2004:202101-01
     steps:
       - sbt-deploy/deploy-service:
-        environment: non-prod
-        service-name: public-api-bookings
-        service-image-new-name: XXXXXX.dkr.ecr.eu-west-1.amazonaws.com/public-api-bookings
-        service-image-new-tag: 1.23.4
-        gitops-ssh-key-fingerprint: "xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx"
-        gitops-repo: git@github.com:ovotech/placeholder-repo.git
-        gitops-username: CircleCI deploy bot
-        gitops-email: deploy-bot@circleci.ovotech.org.uk
-        gitops_overlay_path: overlays/non-prod
+          environment: non-prod
+          service-name: public-api-bookings
+          service-image-new-name: XXXXXX.dkr.ecr.eu-west-1.amazonaws.com/public-api-bookings
+          service-image-new-tag: 1.23.4
+          gitops-ssh-key-fingerprint: "xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx"
+          gitops-repo: git@github.com:ovotech/placeholder-repo.git
+          gitops-username: CircleCI deploy bot
+          gitops-email: deploy-bot@circleci.ovotech.org.uk
+          gitops_overlay_path: overlays/non-prod
 ```

--- a/sbt-deploy/README.md
+++ b/sbt-deploy/README.md
@@ -11,18 +11,19 @@ Requires the K8s cluster to be configured with Argo and Kustomize.
 
 ## Parameters
 
-| Parameter                  | Required |       Default        | Description                             |
-| -------------------------- | :------: | :------------------: | --------------------------------------- |
-| environment                |   Yes    |          -           | Which env to deploy within              |
-| service-name               |   Yes    |          -           | User readable service name              |
-| service-image-new-name     |   Yes    |          -           | Image URI excluding tag                 |
-| service-image-new-tag      |   Yes    |          -           | Tag of image to deploy                  |
-| gitops-ssh-key-fingerprint |   Yes    |          -           | SSH key to allow gitops repo update     |
-| gitops-repo                |   Yes    |          -           | Gitops repository URI                   |
-| gitops-username            |   Yes    |          -           | Username to associate with git actions  |
-| gitops-email               |   Yes    |          -           | Email to associate with git actions     |
-| gitops_overlay_path        |   Yes    |          -           | Path to kustomize overlay to be updated |
-| service-image-current-name |    No    | `SERVICE_IMAGE_NAME` | Placeholder image name text in manifest |
+| Parameter                  | Required |       Default        | Description                                 |
+| -------------------------- | :------: | :------------------: | ------------------------------------------- |
+| environment                |   Yes    |          -           | Which env to deploy within                  |
+| service-name               |   Yes    |          -           | User readable service name                  |
+| service-image-new-name     |   Yes    |          -           | Image URI excluding tag                     |
+| service-image-new-tag      |   Yes    |          -           | Tag of image to deploy                      |
+| gitops-ssh-key-fingerprint |   Yes    |          -           | SSH key to allow gitops repo update         |
+| gitops-repo                |   Yes    |          -           | Gitops repository URI                       |
+| gitops-deploy-branch       |    No    |        `main`        | Gitops repository branch to make changes to |
+| gitops-username            |   Yes    |          -           | Username to associate with git actions      |
+| gitops-email               |   Yes    |          -           | Email to associate with git actions         |
+| gitops_overlay_path        |   Yes    |          -           | Path to kustomize overlay to be updated     |
+| service-image-current-name |    No    | `SERVICE_IMAGE_NAME` | Placeholder image name text in manifest     |
 
 ## Example Usage
 
@@ -37,8 +38,8 @@ jobs:
     steps:
       - sbt-deploy/deploy-service:
           environment: non-prod
-          service-name: public-api-bookings
-          service-image-new-name: XXXXXX.dkr.ecr.eu-west-1.amazonaws.com/public-api-bookings
+          service-name: public-api
+          service-image-new-name: XXXXXX.dkr.ecr.eu-west-1.amazonaws.com/public-api
           service-image-new-tag: 1.23.4
           gitops-ssh-key-fingerprint: "xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx"
           gitops-repo: git@github.com:ovotech/placeholder-repo.git

--- a/sbt-deploy/orb.yml
+++ b/sbt-deploy/orb.yml
@@ -1,7 +1,7 @@
-version: 0.1.0
+version: 2.1
 description: "Deploy images to Argo-managed cluster using Kustomize"
 
-comands:
+commands:
   deploy-service:
     description: "Updates the image tag for a service."
 
@@ -9,7 +9,6 @@ comands:
       environment:
         description: "[Description] Environment in which service is being deployed (e.g. prod/non-prod)."
         type: string
-        default: ${ENVIRONMENT}
       service-name:
         description: "[Description] Service name being deployed (e.g. Public API Bookings)."
         type: string
@@ -52,7 +51,7 @@ comands:
           command: |
             git clone << parameters.gitops-repo >> /tmp/gitops
 
-      - install_kustomize:
+      - run:
           name: Install Kustomize CLI tool
           command: |
             KUSTOMIZE_VERSION=4.0.2
@@ -64,18 +63,18 @@ comands:
           name: Update image tag
           command: |
             cd /tmp/gitops/<< parameters.gitops_overlay_path >>
-            kustomize edit set image << parameters.service-image-placeholder >>=<< parameters.service-image-new-name >>:<< parameters.service-image-new-tag >>
+            kustomize edit set image << parameters.service-image-current-name >>=<< parameters.service-image-new-name >>:<< parameters.service-image-new-tag >>
 
       - run:
-        name: Commit and push changes
-        command: |
-          cd /tmp/gitops
-          git config user.email "<< parameters.gitops-email >>"
-          git config user.name "<< parameters.gitops-username >>"
-          git add --all
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "No changes detected."
-          else
-            git commit -m "Set << parameters.service-name >> << parameters.environment >> image tag to << parameters.service-image-new-tag >>"
-            git push origin master
-          fi
+          name: Commit and push changes
+          command: |
+            cd /tmp/gitops
+            git config user.email "<< parameters.gitops-email >>"
+            git config user.name "<< parameters.gitops-username >>"
+            git add --all
+            if [ -z "$(git status --porcelain)" ]; then
+              echo "No changes detected."
+            else
+              git commit -m "Set << parameters.service-name >> << parameters.environment >> image tag to << parameters.service-image-new-tag >>"
+              git push origin main
+            fi

--- a/sbt-deploy/orb.yml
+++ b/sbt-deploy/orb.yml
@@ -1,0 +1,87 @@
+version: 0.1.0
+description: "Deploy images to Argo-managed cluster using Kustomize"
+
+comands:
+  deploy-service:
+    description: "Updates the image tag for a service."
+
+    parameters:
+      environment:
+        description: "[Description] Environment in which service is being deployed (e.g. prod/non-prod)."
+        type: string
+        default: ${ENVIRONMENT}
+      service-name:
+        description: "[Description] Service name being deployed (e.g. Public API Bookings)."
+        type: string
+        default: ${CIRCLE_PROJECT_REPONAME}
+      service-image-new-name:
+        description: "URI of service image to deploy (excluding tag)."
+        type: string
+      service-image-current-name:
+        description: "Text specified in image name field for deploying service."
+        type: string
+        default: "SERVICE_IMAGE_NAME"
+      service-image-new-tag:
+        description: "Image Registry tag of service to be deployed"
+        type: string
+        default: ${CIRCLE_SHA1}
+      gitops-ssh-key-fingerprint:
+        description: "The github SSH key that will be used to update the repository."
+        type: string
+      gitops-repo:
+        description: "URL for repository containing kubernetes manifests."
+        type: string
+        default: "git@github.com:ovotech/smart-bookings-environments.git"
+      gitops-username:
+        description: "Username to associate with git actions."
+        type: string
+        default: "SME CircleCI User"
+      gitops-email:
+        description: "Email to associate with git actions."
+        type: string
+        default: "circleci@sme-circleci.ovotech.org.uk"
+      gitops_overlay_path:
+        description: "Path to overlay with kustomization.yaml to be updated."
+        type: string
+        default: "overlays/non-prod"
+
+    steps:
+      - attach_workspace:
+          at: .
+
+      - add_ssh_keys:
+          fingerprints:
+            - << parameters.gitops-ssh-key-fingerprint >>
+
+      - run:
+          name: Clone repo
+          command: |
+            git clone << parameters.gitops-repo >> /tmp/gitops
+
+      - install_kustomize:
+          name: Install Kustomize CLI tool
+          command: |
+            KUSTOMIZE_VERSION=4.0.2
+            curl -L -o /usr/local/bin/kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64
+            chmod +x /usr/local/bin/kustomize
+            kustomize version
+
+      - run:
+          name: Update image tag
+          command: |
+            cd /tmp/gitops/<< parameters.gitops_overlay_path >>
+            kustomize edit set image << parameters.service-image-placeholder >>=<< parameters.service-image-new-name >>:<< parameters.service-image-new-tag >>
+
+      - run:
+        name: Commit and push changes
+        command: |
+          cd /tmp/gitops
+          git config user.email "<< parameters.gitops-email >>"
+          git config user.name "<< parameters.gitops-username >>"
+          git add --all
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No changes detected."
+          else
+            git commit -m "Set << parameters.service-name >> << parameters.environment >> image tag to << parameters.service-image-new-tag >>"
+            git push origin master
+          fi

--- a/sbt-deploy/orb.yml
+++ b/sbt-deploy/orb.yml
@@ -13,7 +13,6 @@ comands:
       service-name:
         description: "[Description] Service name being deployed (e.g. Public API Bookings)."
         type: string
-        default: ${CIRCLE_PROJECT_REPONAME}
       service-image-new-name:
         description: "URI of service image to deploy (excluding tag)."
         type: string
@@ -24,26 +23,21 @@ comands:
       service-image-new-tag:
         description: "Image Registry tag of service to be deployed"
         type: string
-        default: ${CIRCLE_SHA1}
       gitops-ssh-key-fingerprint:
         description: "The github SSH key that will be used to update the repository."
         type: string
       gitops-repo:
         description: "URL for repository containing kubernetes manifests."
         type: string
-        default: "git@github.com:ovotech/smart-bookings-environments.git"
       gitops-username:
         description: "Username to associate with git actions."
         type: string
-        default: "SME CircleCI User"
       gitops-email:
         description: "Email to associate with git actions."
         type: string
-        default: "circleci@sme-circleci.ovotech.org.uk"
       gitops_overlay_path:
         description: "Path to overlay with kustomization.yaml to be updated."
         type: string
-        default: "overlays/non-prod"
 
     steps:
       - attach_workspace:

--- a/sbt-deploy/orb.yml
+++ b/sbt-deploy/orb.yml
@@ -28,6 +28,10 @@ commands:
       gitops-repo:
         description: "URL for repository containing kubernetes manifests."
         type: string
+      gitops-deploy-branch:
+        description: "Branch in which to update image tag"
+        type: string
+        default: "main"
       gitops-username:
         description: "Username to associate with git actions."
         type: string
@@ -76,5 +80,5 @@ commands:
               echo "No changes detected."
             else
               git commit -m "Set << parameters.service-name >> << parameters.environment >> image tag to << parameters.service-image-new-tag >>"
-              git push origin main
+              git push origin << parameters.gitops-deploy-branch >>
             fi

--- a/sbt-deploy/orb_version.txt
+++ b/sbt-deploy/orb_version.txt
@@ -1,0 +1,1 @@
+ovotech/sbt-deploy@0.1.0


### PR DESCRIPTION
This orb allows teams with a gitops workflow using [ArgoCD](https://argoproj.github.io/argo-cd/) and [Kustomize](https://github.com/kubernetes-sigs/kustomize) to automatically deploy a service in a specific environment.

This is done through updating an overlay's kustomize configuration which specifies the deployable image tag for the service. Editing this should trigger a re-sync in Argo and thereby cause a new version of the service to be deployed.