### PR TITLE
Allow custom SSH key host + make fingerprint optional

### DIFF
--- a/sbt-deploy/README.md
+++ b/sbt-deploy/README.md
@@ -46,7 +46,7 @@ jobs:
           service-image-current-name: SOME_SERVICE_PLACEHOLDER
           service-image-new-name: XXXXXX.dkr.ecr.eu-west-1.amazonaws.com/public-api
           service-image-new-tag: 1.23.4
-          gitops-repo: git@github.com:ovotech/placeholder-repo.git
+          gitops-repo: git@ghgitops:ovotech/placeholder-repo.git
           gitops-username: CircleCI deploy bot
           gitops-email: deploy-bot@circleci.ovotech.org.uk
           gitops_overlay_path: overlays/non-prod

--- a/sbt-deploy/README.md
+++ b/sbt-deploy/README.md
@@ -7,29 +7,33 @@ Requires the K8s cluster to be configured with Argo and Kustomize.
 ## Prerequisites
 
 - Github deploy key with push rights to the gitops repo needs to be added to the `Additional SSH keys` setting in consuming CircleCI project.
-  - The host name should be "github.com".
+  - The host name should be the git repository host e.g. "github.com".
+  - If the SSH key fingerprint is already being added before this job runs, it does not need to be specified.
+  - If an SSH key already exists with the host name required, you can use a custom identifier by specifying `gitops-repo-ssh-key-host` and `gitops-repo-ssh-key-hostname` where the `host` is the custom identifier and `hostname` is the host name.
 
 ## Parameters
 
-| Parameter                  | Required |       Default        | Description                                 |
-| -------------------------- | :------: | :------------------: | ------------------------------------------- |
-| environment                |   Yes    |          -           | Which env to deploy within                  |
-| service-name               |   Yes    |          -           | User readable service name                  |
-| service-image-new-name     |   Yes    |          -           | Image URI excluding tag                     |
-| service-image-new-tag      |   Yes    |          -           | Tag of image to deploy                      |
-| gitops-ssh-key-fingerprint |   Yes    |          -           | SSH key to allow gitops repo update         |
-| gitops-repo                |   Yes    |          -           | Gitops repository URI                       |
-| gitops-deploy-branch       |    No    |        `main`        | Gitops repository branch to make changes to |
-| gitops-username            |   Yes    |          -           | Username to associate with git actions      |
-| gitops-email               |   Yes    |          -           | Email to associate with git actions         |
-| gitops_overlay_path        |   Yes    |          -           | Path to kustomize overlay to be updated     |
-| service-image-current-name |    No    | `SERVICE_IMAGE_NAME` | Placeholder image name text in manifest     |
+| Parameter                       | Required |   Default    | Description                                        |
+| ------------------------------- | :------: | :----------: | -------------------------------------------------- |
+| environment                     |   Yes    |      -       | Which env to deploy within                         |
+| service-name                    |   Yes    |      -       | User readable service name                         |
+| service-image-current-name      |   Yes    |      -       | Placeholder image name text in manifest            |
+| service-image-new-name          |   Yes    |      -       | Image URI excluding tag                            |
+| service-image-new-tag           |   Yes    |      -       | Tag of image to deploy                             |
+| gitops-repo                     |   Yes    |      -       | Gitops repository URI                              |
+| gitops-deploy-branch            |    No    |    `main`    | Gitops repository branch to make changes to        |
+| gitops-username                 |   Yes    |      -       | Username to associate with git actions             |
+| gitops-email                    |   Yes    |      -       | Email to associate with git actions                |
+| gitops_overlay_path             |   Yes    |      -       | Path to kustomize overlay to be updated            |
+| gitops-repo-ssh-key-fingerprint |    No    |      -       | SSH key to allow gitops repo update                |
+| gitops-repo-ssh-key-host        |    No    |      -       | Custom host identifier for SSH key                 |
+| gitops-repo-ssh-key-hostname    |    No    | `github.com` | SSH key host name if custom host identifier is set |
 
 ## Example Usage
 
 ```yaml
 orbs:
-  sbt-deploy: ovotech/sbt-deploy@0.1.1
+  sbt-deploy: ovotech/sbt-deploy@1.1.0
 
 jobs:
   deploy-to-uat:
@@ -39,11 +43,14 @@ jobs:
       - sbt-deploy/deploy-service:
           environment: non-prod
           service-name: public-api
+          service-image-current-name: SOME_SERVICE_PLACEHOLDER
           service-image-new-name: XXXXXX.dkr.ecr.eu-west-1.amazonaws.com/public-api
           service-image-new-tag: 1.23.4
-          gitops-ssh-key-fingerprint: "xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx"
           gitops-repo: git@github.com:ovotech/placeholder-repo.git
           gitops-username: CircleCI deploy bot
           gitops-email: deploy-bot@circleci.ovotech.org.uk
           gitops_overlay_path: overlays/non-prod
+          gitops-repo-ssh-key-fingerprint: "xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx"
+          gitops-repo-ssh-key-host: ghgitops
+          gitops-repo-ssh-key-hostname: github.com
 ```

--- a/sbt-deploy/orb.yml
+++ b/sbt-deploy/orb.yml
@@ -18,20 +18,12 @@ commands:
       service-image-current-name:
         description: "Text specified in image name field for deploying service."
         type: string
-        default: "SERVICE_IMAGE_NAME"
       service-image-new-tag:
         description: "Image Registry tag of service to be deployed"
-        type: string
-      gitops-ssh-key-fingerprint:
-        description: "The github SSH key that will be used to update the repository."
         type: string
       gitops-repo:
         description: "URL for repository containing kubernetes manifests."
         type: string
-      gitops-deploy-branch:
-        description: "Branch in which to update image tag"
-        type: string
-        default: "main"
       gitops-username:
         description: "Username to associate with git actions."
         type: string
@@ -41,14 +33,41 @@ commands:
       gitops_overlay_path:
         description: "Path to overlay with kustomization.yaml to be updated."
         type: string
+      gitops-deploy-branch:
+        description: "Branch in which to update image tag"
+        type: string
+        default: "main"
+      gitops-repo-ssh-key-fingerprint:
+        description: "The github SSH key that will be used to update the repository."
+        type: string
+        default: ""
+      gitops-repo-ssh-key-host:
+        description: 'A host identifier to be set if multiple "Additional SSH keys" require a custom host to be set for the gitops repository, so as not to confict with another host.'
+        type: string
+        default: ""
+      gitops-repo-ssh-key-hostname:
+        description: "Optional HostName to update ssh config with, if gitops-repo-host is set."
+        type: string
+        default: github.com
 
     steps:
       - attach_workspace:
-          at: .
+          at: /tmp/workspace
 
-      - add_ssh_keys:
-          fingerprints:
-            - << parameters.gitops-ssh-key-fingerprint >>
+      - when:
+          condition: << parameters.gitops-repo-ssh-key-fingerprint >>
+          steps:
+            - add_ssh_keys:
+                fingerprints:
+                  - << parameters.gitops-repo-ssh-key-fingerprint >>
+
+      - when:
+          condition: << parameters.gitops-repo-ssh-key-host >>
+          steps:
+            - run:
+                name: Update SSH config hostnames
+                command: |
+                  sed -i -e 's/Host << parameters.gitops-repo-ssh-key-host >>/<< parameters.gitops-repo-ssh-key-host >>\n  HostName << parameters.gitops-repo-ssh-key-hostname >>/g' ~/.ssh/config
 
       - run:
           name: Clone repo

--- a/sbt-deploy/orb.yml
+++ b/sbt-deploy/orb.yml
@@ -67,7 +67,7 @@ commands:
             - run:
                 name: Update SSH config hostnames
                 command: |
-                  sed -i -e 's/Host << parameters.gitops-repo-ssh-key-host >>/<< parameters.gitops-repo-ssh-key-host >>\n  HostName << parameters.gitops-repo-ssh-key-hostname >>/g' ~/.ssh/config
+                  sed -i -e 's/Host << parameters.gitops-repo-ssh-key-host >>/Host << parameters.gitops-repo-ssh-key-host >>\n  HostName << parameters.gitops-repo-ssh-key-hostname >>/g' ~/.ssh/config
 
       - run:
           name: Clone repo

--- a/sbt-deploy/orb_version.txt
+++ b/sbt-deploy/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/sbt-deploy@0.1.1
+ovotech/sbt-deploy@1.1.0


### PR DESCRIPTION
- SSH fingerprint is now optional
- Now allows a custom SSH key host mapped to hostname to be specified (for when additional SSH keys have identical hosts).