### PR TITLE
gcp-rotate-keys: Better timezone handling

### DIFF
--- a/gcp-rotate-keys/orb_version.txt
+++ b/gcp-rotate-keys/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/gcp-rotate-keys@1.0.1
+ovotech/gcp-rotate-keys@1.0.2

--- a/gcp-rotate-keys/scripts/redeploy-ecs.sh
+++ b/gcp-rotate-keys/scripts/redeploy-ecs.sh
@@ -34,6 +34,7 @@ redeploy_ecs() {
           | map(select(
             (.createdAt
               | sub("(?<time>T[0-9:]+)(\\.\\d+)?(?<tz>Z|[+\\-]\\d{2}:?(\\d{2})?)$"; .time + .tz)
+              | sub("Z$"; "+00:00")
               | sub("(?<h>[+\\-]\\d{2}):?(?<m>\\d{2})$"; .h + .m)
               | strptime("%Y-%m-%dT%H:%M:%S%z")
               | mktime >= ($now | tonumber))

--- a/gcp-rotate-keys/scripts/redeploy-ecs.sh
+++ b/gcp-rotate-keys/scripts/redeploy-ecs.sh
@@ -28,7 +28,7 @@ redeploy_ecs() {
 
     _UPDATED=$(
       AWS_PAGER="" aws ecs describe-services --cluster "${_CLUSTER}" --service "${_SERVICE}" \
-        | jq --arg now "${_START}" --arg name "${_SERVICE}" \
+        | TZ=UTC jq --arg now "${_START}" --arg name "${_SERVICE}" \
           '.services[]
           | select(.serviceName == $name).events
           | map(select(

--- a/gcp-rotate-keys/scripts/redeploy-ecs.sh
+++ b/gcp-rotate-keys/scripts/redeploy-ecs.sh
@@ -32,7 +32,11 @@ redeploy_ecs() {
           '.services[]
           | select(.serviceName == $name).events
           | map(select(
-            (.createdAt | sub("\\.[0-9]+\\+00:00"; "Z") | fromdate >= ($now | tonumber))
+            (.createdAt
+              | sub("(?<time>T[0-9:]+)(\\.\\d+)?(?<tz>Z|[+\\-]\\d{2}:?(\\d{2})?)$"; .time + .tz)
+              | sub("(?<h>[+\\-]\\d{2}):?(?<m>\\d{2})$"; .h + .m)
+              | strptime("%Y-%m-%dT%H:%M:%S%z")
+              | mktime >= ($now | tonumber))
             and
             (.message | contains("reached a steady state"))
           ))


### PR DESCRIPTION
This PR improves the timezone handling with `jq` when comparing dates of events.