### PR TITLE
Remove sbt-dependency-graph

### DIFF
--- a/rac-gcp-deploy/orb.yml
+++ b/rac-gcp-deploy/orb.yml
@@ -2,8 +2,6 @@ version: 2.1
 description: An orb to build scala services and deploy them to a Kubernetes cluster running on Google Cloud
 
 aliases:
-  # Once all projects are using sbt >=1.4.0 we can remove this as the plugin is now part of sbt
-  - &sbt-dependency-graph echo 'addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")' > project/sbt-dependency-graph.sbt
   - &cache-key '{{ .Environment.CIRCLE_PROJECT_REPONAME }}-{{ .Branch }}-{{ checksum "project/Dependencies.scala"}}'
 
 .gcloud_auth_uat: &gcloud_auth_uat
@@ -167,7 +165,6 @@ commands:
 
   snyk_monitor:
     steps:
-      - run: *sbt-dependency-graph
       - snyk/scan:
           project: $CIRCLE_PROJECT_REPONAME
           fail-on-issues: false
@@ -376,7 +373,6 @@ jobs:
       - load_cache:
           cache-key: <<parameters.cache-key>>
           cache-suffix: <<parameters.cache-suffix>>
-      - run: *sbt-dependency-graph
       - when:
           condition: <<parameters.enable-pr-comment>>
           steps:


### PR DESCRIPTION
This plugin is now deprecated as it's been integrated directly into Sbt.
This plugin contains dependencies that are still hosted in Bintray. Given that the plugin is deprecated and Bintray is going to be terminated on 1st May, it's probable that the plugin is not going to be updated. If this is the case, it will cause our builds to fail.

Given that most of our services are using sbt > 1.4.x, I prefer to remove the injection of the plugin and update the services that might fail due to lack of it. 

Deprecation notice: https://github.com/sbt/sbt-dependency-graph