### PR TITLE
Fix: jaws gitops deploy

### DIFF
--- a/jaws-journey-deploy/scripts/save_test_results.sh
+++ b/jaws-journey-deploy/scripts/save_test_results.sh
@@ -6,6 +6,7 @@ mkdir -p ~/test-results/junit/
 find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
 mkdir -p ./reports/jacoco/
 mkdir -p ./reports/jacoco/"$SERVICE_NAME"/
+rm -rf ./reports/jacoco/*
 
 REPORT_FOLDER=""
 if [[ "$IS_LIB" = true ]] ; then

--- a/jaws-journey-deploy/scripts/update_helm.sh
+++ b/jaws-journey-deploy/scripts/update_helm.sh
@@ -1,10 +1,35 @@
-git clone git@github.com:${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} /tmp/gitops
-cd /tmp/gitops
+MAX_RETRY=3
+COUNTER=0
 
-yq e ".jaws-journey-helm-chart.buildTag=\"${CIRCLE_SHA1}\"" -i <<parameters.manifest_directory>>/values-<<parameters.environment>>.yaml
-yq e ".jaws-journey-helm-chart.releaseVersion=\"${CIRCLE_TAG:-$CIRCLE_BRANCH-${CIRCLE_SHA1:0:8}}\"" -i <<parameters.manifest_directory>>/values-<<parameters.environment>>.yaml
+function deply_manifest {
 
-git config user.name '<<parameters.git_name>>'
-git config user.email '<<parameters.git_email>>'
-git commit -m "[skip ci] CircleCI deploy with helm ${CIRCLE_PROJECT_REPONAME}" -m  "Build URL: ${CIRCLE_BUILD_URL}" -a
-git push origin master
+  # Ensure /tmp/gitops is empty
+  cd ~/
+  rm -rf /tmp/gitops
+  mkdir -p /tmp/gitops
+  
+  # Clone manifest repo
+  git clone git@github.com:${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} /tmp/gitops
+  cd /tmp/gitops
+  
+  # Update helm chart
+  yq e ".jaws-journey-helm-chart.buildTag=\"${CIRCLE_SHA1}\"" -i <<parameters.manifest_directory>>/values-<<parameters.environment>>.yaml
+  yq e ".jaws-journey-helm-chart.releaseVersion=\"${CIRCLE_TAG:-$CIRCLE_BRANCH-${CIRCLE_SHA1:0:8}}\"" -i <<parameters.manifest_directory>>/values-<<parameters.environment>>.yaml
+  
+  # Commit manifest changes
+  git config user.name '<<parameters.git_name>>'
+  git config user.email '<<parameters.git_email>>'
+  git commit -m "[skip ci] CircleCI deploy with helm ${CIRCLE_PROJECT_REPONAME}" -m  "Build URL: ${CIRCLE_BUILD_URL}" -a
+  git push origin master
+
+  return $?
+}
+
+
+until deply_manifest
+do
+   sleep 1
+   [[ COUNTER -eq $MAX_RETRY ]] && echo "Failed!" && exit 1
+   echo "Trying again. Try #$COUNTER"
+   ((COUNTER++))
+done

--- a/jaws-journey-deploy/scripts/update_helm.sh
+++ b/jaws-journey-deploy/scripts/update_helm.sh
@@ -19,7 +19,7 @@ function deply_manifest {
   # Commit manifest changes
   git config user.name '<<parameters.git_name>>'
   git config user.email '<<parameters.git_email>>'
-  git commit -m "[skip ci] CircleCI deploy with helm ${CIRCLE_PROJECT_REPONAME}" -m  "Build URL: ${CIRCLE_BUILD_URL}" -a
+  git commit -m "[skip ci] <<parameters.environment>>: CircleCI deploy ${CIRCLE_PROJECT_REPONAME}" -m  "Deployment to <<parameters.environment>>. Build URL: ${CIRCLE_BUILD_URL}" -a
   git push origin master
 
   return $?


### PR DESCRIPTION
- Retry committing manifests in case head of the branch has moved
- Ensure `./reports/jacoco/` directory is empty
- Include environment in manifest commit