### PR TITLE
Add version check to new terraform-v2 orb

### DIFF
--- a/terraform-v2/CHANGELOG.md
+++ b/terraform-v2/CHANGELOG.md
@@ -3,5 +3,9 @@ All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
 not listed
 
+## ovotech/terraform-v2@2.1.0
+Add terraform version check that fails the build with a helpful
+message if the terraform version <0.14.
+
 ## ovotech/terraform-v2@2.0.0
 Start of the changelog

--- a/terraform-v2/orb_version.txt
+++ b/terraform-v2/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform-v2@2.0.0
+ovotech/terraform-v2@2.1.0

--- a/terraform-v2/setup.sh
+++ b/terraform-v2/setup.sh
@@ -15,8 +15,7 @@ if hash tfswitch 2>/dev/null; then
 fi
 
 # Check the terraform version is >= 0.14
-tf_minor_version=$(terraform version -json | jq -r .terraform_version | cut -b 3,4)
-if ! terraform version -help | grep -e "-json" >/dev/null || [ ${tf_minor_version} -lt 14 ]; then
+if ! terraform version -help | grep -e "-json" >/dev/null || [ $(terraform version -json | jq -r .terraform_version | cut -b 3,4) -lt 14 ]; then
     echo "Your version of terraform is too old. The terraform v2 orb only supports terraform >= 0.14"
     exit 1
 fi

--- a/terraform-v2/setup.sh
+++ b/terraform-v2/setup.sh
@@ -14,6 +14,13 @@ if hash tfswitch 2>/dev/null; then
   (cd "$module_path" && echo "" | tfswitch | grep -e Switched -e Reading | sed 's/^.*Switched/Switched/')
 fi
 
+# Check the terraform version is >= 0.14
+tf_minor_version=$(terraform version -json | jq -r .terraform_version | cut -b 3,4)
+if ! terraform version -help | grep -e "-json" >/dev/null || [ ${tf_minor_version} -lt 14 ]; then
+    echo "Your version of terraform is too old. The terraform v2 orb only supports terraform >= 0.14"
+    exit 1
+fi
+
 if [ -n "$TF_REGISTRY_TOKEN" ]; then
     echo "credentials \"$TF_REGISTRY_HOST\" { token = \"$TF_REGISTRY_TOKEN\" }" >>$HOME/.terraformrc
 fi

--- a/terraform-v2/v1-to-v2.md
+++ b/terraform-v2/v1-to-v2.md
@@ -50,7 +50,7 @@ orbs:
 ```
 
 This will use the latest 2.x.x version of the v2 orb, you can pin to a more
-precise version, e.g. 2.0 or 2.0.0 if required.
+precise version, e.g. 2.1 or 2.1.0 if required.
 
 Ensure you specify the default executor:
 


### PR DESCRIPTION
The new terraform-v2 orb only support terraform >= 0.14. Currently it fails with an unclear message if you try to use an older version of terraform. This hopefully makes it clearer. It'll need adjusting when terraform v1 comes out but I imagine a number of things will need changing when that happens.