### PR TITLE
Add git into terraform v2 docker image

### DIFF
--- a/terraform-v2/orb.yml
+++ b/terraform-v2/orb.yml
@@ -5,7 +5,7 @@ executors:
   default:
     description: "Terraform executor"
     docker:
-      - image: ovotech/terraform:latest
+      - image: ovotech/terraform:add-git-to-terraform-v2_04-06-2021
 
 aliases:
   parameters:

--- a/terraform-v2/orb.yml
+++ b/terraform-v2/orb.yml
@@ -5,7 +5,7 @@ executors:
   default:
     description: "Terraform executor"
     docker:
-      - image: ovotech/terraform:add-git-to-terraform-v2_04-06-2021
+      - image: ovotech/terraform:latest
 
 aliases:
   parameters:

--- a/terraform/executor/Dockerfile
+++ b/terraform/executor/Dockerfile
@@ -19,6 +19,7 @@ ENV TF_INPUT=false
 ENV TF_PLUGIN_CACHE_DIR=/usr/local/share/terraform/plugin-cache
 
 RUN apt-get update && apt-get install -y \
+    git \
     ssh \
     tar \
     gzip \


### PR DESCRIPTION
Fixes this error
```
error downloading 'https://github.com/ovotech/terraform-module-fargate-app.git?ref=3.1.8': git must be available and on the PATH
```
when using git sourced terraform modules.

Not bumping the orb version as the terraform-v2 orb pulls the latest tag, so all versions will be updated by this.