### PR TITLE
Bump argocd version

### DIFF
--- a/argocd/orb_version.txt
+++ b/argocd/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/argocd@0.1.0
+ovotech/argocd@1.0.0


### PR DESCRIPTION
CircleCI seems to have published this as 1.0.0, not 0.1.0.