### PR TITLE
Prompt terraform 0.15 users to use the v2 orb

### DIFF
--- a/terraform/CHANGELOG.md
+++ b/terraform/CHANGELOG.md
@@ -4,6 +4,10 @@ Orbs are immutable, some orb versions with no significant changes are
 not listed
 
 
+## ovotech/terraform@1.8.8
+## Added
+- Added explicit version check, signposting terraform >0.14 users to v2 orb
+
 ## ovotech/terraform@1.8.7
 ## Added
 - Added Terraform provider Aiven Kafka Users v1.0.1

--- a/terraform/orb_version.txt
+++ b/terraform/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform@1.8.7
+ovotech/terraform@1.8.8

--- a/terraform/setup.sh
+++ b/terraform/setup.sh
@@ -12,6 +12,14 @@ if hash tfswitch 2>/dev/null; then
   (cd "$module_path" && echo "" | tfswitch | grep -e Switched -e Reading | sed 's/^.*Switched/Switched/')
 fi
 
+# Check the terraform version is <= 0.14
+if terraform version -help | grep -e "-json" >/dev/null; then
+    if  $(terraform version -json | jq -r .terraform_version | cut -b 3,4) -gt 14 ; then
+        echo "The terraform orb does not support terraform 0.15+. Please use the terraform-v2 orb."
+        exit 1
+    fi
+fi
+
 if [ -n "$TF_REGISTRY_TOKEN" ]; then
     echo "credentials \"$TF_REGISTRY_HOST\" { token = \"$TF_REGISTRY_TOKEN\" }" >>$HOME/.terraformrc
 fi

--- a/terraform/setup.sh
+++ b/terraform/setup.sh
@@ -12,10 +12,15 @@ if hash tfswitch 2>/dev/null; then
   (cd "$module_path" && echo "" | tfswitch | grep -e Switched -e Reading | sed 's/^.*Switched/Switched/')
 fi
 
-terraform version
-jq
-cut
-grep
+# Check that the terraform version isn't greater than 0.14
+if terraform version -help | grep -e "-json" >/dev/null; then
+    tf_version=$(terraform version -json | jq -r .terraform_version)
+    if  [ $(echo -n ${tf_version} | sed 's/^\([0-9]\).*/\1/') -ge 1 ] || [ $(echo -n ${tf_version} | sed 's/^[0-9]\.\([0-9][0-9]\)\.[0-9]*/\1/') -ge 15 ] ; then
+        echo "The terraform orb does not support terraform 0.15+. Please use the terraform-v2 orb."
+        echo "https://circleci.com/developer/orbs/orb/ovotech/terraform-v2"
+        exit 1
+    fi
+fi
 
 if [ -n "$TF_REGISTRY_TOKEN" ]; then
     echo "credentials \"$TF_REGISTRY_HOST\" { token = \"$TF_REGISTRY_TOKEN\" }" >>$HOME/.terraformrc
@@ -72,13 +77,4 @@ fi
 COMPACT_PLAN=compact_plan
 if ! hash $COMPACT_PLAN 2>/dev/null; then
     COMPACT_PLAN=cat
-fi
-
-# Check the terraform version is <= 0.14
-if terraform version -help | grep -e "-json" >/dev/null; then
-    if  $(terraform version -json | jq -r .terraform_version | cut -b 3,4) -gt 14 ; then
-        echo "The terraform orb does not support terraform 0.15+. Please use the terraform-v2 orb."
-        echo "https://circleci.com/developer/orbs/orb/ovotech/terraform-v2"
-        exit 1
-    fi
 fi

--- a/terraform/setup.sh
+++ b/terraform/setup.sh
@@ -12,14 +12,10 @@ if hash tfswitch 2>/dev/null; then
   (cd "$module_path" && echo "" | tfswitch | grep -e Switched -e Reading | sed 's/^.*Switched/Switched/')
 fi
 
-# Check the terraform version is <= 0.14
-if terraform version -help | grep -e "-json" >/dev/null; then
-    if  $(terraform version -json | jq -r .terraform_version | cut -b 3,4) -gt 14 ; then
-        echo "The terraform orb does not support terraform 0.15+. Please use the terraform-v2 orb."
-        echo "https://circleci.com/developer/orbs/orb/ovotech/terraform-v2"
-        exit 1
-    fi
-fi
+terraform version
+jq
+cut
+grep
 
 if [ -n "$TF_REGISTRY_TOKEN" ]; then
     echo "credentials \"$TF_REGISTRY_HOST\" { token = \"$TF_REGISTRY_TOKEN\" }" >>$HOME/.terraformrc
@@ -76,4 +72,13 @@ fi
 COMPACT_PLAN=compact_plan
 if ! hash $COMPACT_PLAN 2>/dev/null; then
     COMPACT_PLAN=cat
+fi
+
+# Check the terraform version is <= 0.14
+if terraform version -help | grep -e "-json" >/dev/null; then
+    if  $(terraform version -json | jq -r .terraform_version | cut -b 3,4) -gt 14 ; then
+        echo "The terraform orb does not support terraform 0.15+. Please use the terraform-v2 orb."
+        echo "https://circleci.com/developer/orbs/orb/ovotech/terraform-v2"
+        exit 1
+    fi
 fi

--- a/terraform/setup.sh
+++ b/terraform/setup.sh
@@ -16,6 +16,7 @@ fi
 if terraform version -help | grep -e "-json" >/dev/null; then
     if  $(terraform version -json | jq -r .terraform_version | cut -b 3,4) -gt 14 ; then
         echo "The terraform orb does not support terraform 0.15+. Please use the terraform-v2 orb."
+        echo "https://circleci.com/developer/orbs/orb/ovotech/terraform-v2"
         exit 1
     fi
 fi


### PR DESCRIPTION
The terraform fails with an unhelpful message currently if you try to use it with terraform 0.15+. This makes the error message more explicit and helpful.