### PR TITLE
Update publish module script to prevent overwriting previous versions

### DIFF
--- a/terraform-v2/publish.sh
+++ b/terraform-v2/publish.sh
@@ -60,6 +60,13 @@ if [[ "$REGISTRY_URL" == "" ]]; then
     exit 2
 fi
 
+EXISTING_VERSION=$(curl "${REGISTRY_URL}${MODULE_NAME}/versions" | jq -c '.modules[0].versions[] | select(.version == '\"$VERSION\"')')
+
+if [[ ! -z "$EXISTING_VERSION" ]]; then
+    echo "Version $VERSION already exists"
+    exit 2
+fi
+
 curl -L --fail -X PUT "$REGISTRY_URL$MODULE_NAME/$VERSION/upload" \
  --data-binary "@/tmp/$VERSION.tar.gz" \
  -H "Content-Type: application/x-tar" \

--- a/terraform/publish.sh
+++ b/terraform/publish.sh
@@ -59,6 +59,14 @@ if [[ "$REGISTRY_URL" == "" ]]; then
     exit 2
 fi
 
+
+EXISTING_VERSION=$(curl "${REGISTRY_URL}${MODULE_NAME}/versions" | jq -c '.modules[0].versions[] | select(.version == '\"$VERSION\"')')
+
+if [[ ! -z "$EXISTING_VERSION" ]]; then
+    echo "Version $VERSION already exists"
+    exit 2
+fi
+
 curl -L --fail -X PUT "$REGISTRY_URL$MODULE_NAME/$VERSION/upload" \
  --data-binary "@/tmp/$VERSION.tar.gz" \
  -H "Content-Type: application/x-tar" \


### PR DESCRIPTION
Currently if a terraform module is published without bumping the module
version it will overwrite the existing version. That could cause issues
for users of that module if it includes breaking changes.

This checks if a version already exists before publishing.