### PR TITLE
Fixes ArgoCD up not waiting until application has finished progressing

### DIFF
--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -8,7 +8,7 @@ orbs:
   snyk: snyk/snyk@0.0.10
   shipit: ovotech/shipit@1
   slack: circleci/slack@4.1.3
-  argocd: ovotech/argocd@1.0.0
+  argocd: ovotech/argocd@1.0.1
 
 executors:
   kotlin:

--- a/jaws-journey-deploy/orb_version.txt
+++ b/jaws-journey-deploy/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/jaws-journey-deploy@1.11.3
+ovotech/jaws-journey-deploy@1.11.4


### PR DESCRIPTION
ArgoCD reports as being 'in-sync' while still (for example) rolling out
new pods in a statefulset. The 1.0.1 fixes this by waiting until the Argo
Application is no longer 'Progressing'.