### PR TITLE
Update aws-ecr orb to fix python2 deprecation

### DIFF
--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -2,7 +2,7 @@ version: 2.1
 description: "Defines the core steps required for a smart journey deployment pipeline"
 
 orbs:
-  aws-ecr: circleci/aws-ecr@6.3.0
+  aws-ecr: circleci/aws-ecr@7.0.0
   terraform: ovotech/terraform@1.8.2
   openjdk-install: cloudesire/openjdk-install@1.2.3
   snyk: snyk/snyk@0.0.10

--- a/jaws-journey-deploy/orb_version.txt
+++ b/jaws-journey-deploy/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/jaws-journey-deploy@1.11.3
+ovotech/jaws-journey-deploy@1.11.4


### PR DESCRIPTION
Resolves this issue [https://app.circleci.com/pipelines/github/ovotech/jaws-journey-reconcile-device-store/338/workflows/44c9ff62-a97a-426d-abb5-9d5db6d2c298/jobs/3341](https://app.circleci.com/pipelines/github/ovotech/jaws-journey-reconcile-device-store/338/workflows/44c9ff62-a97a-426d-abb5-9d5db6d2c298/jobs/3341)

Some more context [https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/)