### PR TITLE
Add Terraform 1.0.X compatible check to compact_plan

### DIFF
--- a/terraform/executor/compact_plan.py
+++ b/terraform/executor/compact_plan.py
@@ -10,6 +10,7 @@ def compact_plan(input):
     for line in input:
 
         if not plan and (
+            line.startswith('Terraform used the selected providers to generate') or
             line.startswith('An execution plan has been generated and is shown below') or
             line.startswith('No changes') or
             line.startswith('Error')

--- a/terraform/executor/test_compact_plan.py
+++ b/terraform/executor/test_compact_plan.py
@@ -256,3 +256,62 @@ This should protect against the output changing again."""
     output = '\n'.join(compact_plan(input.splitlines()))
     assert output == expected_output
 
+def test_plan_1_0():
+    input_one = """
+STATE_REFRESH_1
+STATE_REFRESH_2
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+
+# random_string.my_string will be created
++ random_string.my_string
+      + id:          <computed>
+      + length:      "11"
+      + lower:       "true"
+      + min_lower:   "0"
+      + min_numeric: "0"
+      + min_special: "0"
+      + min_upper:   "0"
+      + number:      "true"
+      + result:      <computed>
+      + special:     "true"
+      + upper:       "true"
+
+Plan: 1 to add, 0 to change, 0 to destroy."""
+
+    input_two = """
+STATE_REFRESH_2
+STATE_REFRESH_1
+
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+
+Terraform will perform the following actions:
+
+
+# random_string.my_string will be created
++ random_string.my_string
+      + id:          <computed>
+      + length:      "11"
+      + lower:       "true"
+      + min_lower:   "0"
+      + min_numeric: "0"
+      + min_special: "0"
+      + min_upper:   "0"
+      + number:      "true"
+      + result:      <computed>
+      + special:     "true"
+      + upper:       "true"
+
+Plan: 1 to add, 0 to change, 0 to destroy."""
+
+    clipped_output_one = list(compact_plan(input_one.splitlines()))
+    clipped_output_two = list(compact_plan(input_two.splitlines()))
+    assert clipped_output_one == clipped_output_two
+    assert len(clipped_output_one) > 0


### PR DESCRIPTION
This is from https://github.com/ovotech/circleci-orbs/pull/316. I've pushed the branch to the main repo so that the tests can run and to build a dev version of the new executor for manual testing.

'An execution plan....' does not appear in the output of Terraform plan/apply
for version 1.0.1 — this means that the simple examples of a plan-on-branch,
apply-on-main flow have high chances of never working:

The full plan output will be used for an exact string comparison, and it just
so happens that resource states can be refreshed in different orders. This means
that if comparing the two, they will often not match, despite the resulting
plan being completely identical in effect.

Adding 'Terraform will perform the following actions' will clip out just the lines
with the actions!

What do I need to do to get this in to a new version of the executor please?
Happy to get stuck in smile I've added a happy-path test for the use case that
triggered my involvement here.

See https://app.circleci.com/pipelines/github/ovotech/foyer-infra/31/workflows/98b82903-942c-4b53-afd0-8d1c8e3f7c84/jobs/36 for an example of this happening.