### PR TITLE
Add a wait_for_ecs_deployment command

### DIFF
--- a/comms-commands/orb.yml
+++ b/comms-commands/orb.yml
@@ -150,6 +150,24 @@ commands:
               << parameters.ecr_aws_account >>.dkr.ecr.eu-west-1.amazonaws.com/<< parameters.service_name >>:<< parameters.publish_commit_sha >>
           no_output_timeout: 20m
 
+  wait_for_ecs_deployment:
+    description: "Waits for the active deployment to complete"
+    parameters:
+      cluster:
+        type: string
+      service:
+        type: string
+    steps:
+      - checkout
+      - run:
+          name: Restart ecs service
+          environment:
+            - WAIT_ONLY: "true"
+            - ECS_CLUSTER: << parameters.cluster >>
+            - ECS_SERVICE: << parameters.service >>
+          command: |
+            include restart_ecs_service.sh
+
   restart_ecs_service:
     description: "Restart an ECS service w/o updating task definition"
     parameters:

--- a/comms-commands/orb.yml
+++ b/comms-commands/orb.yml
@@ -160,7 +160,7 @@ commands:
     steps:
       - checkout
       - run:
-          name: Restart ecs service
+          name: Wait for ecs deployment
           environment:
             - WAIT_ONLY: "true"
             - ECS_CLUSTER: << parameters.cluster >>

--- a/comms-commands/restart_ecs_service.sh
+++ b/comms-commands/restart_ecs_service.sh
@@ -2,12 +2,15 @@
 
 set -eo pipefail
 
-aws ecs update-service \
-  --force-new-deployment \
-  --cluster "${ECS_CLUSTER}" \
-  --service "${ECS_SERVICE}" \
-  --query "service.deployments[?status=='PRIMARY'][]" \
-  --no-cli-pager
+if [[ "${WAIT_ONLY}" != "true" ]]
+then
+  aws ecs update-service \
+    --force-new-deployment \
+    --cluster "${ECS_CLUSTER}" \
+    --service "${ECS_SERVICE}" \
+    --query "service.deployments[?status=='PRIMARY'][]" \
+    --no-cli-pager
+fi
 
 while :
 do


### PR DESCRIPTION
Allows for waiting the completion of an ECS deployment without restarting the
service.