### PR TITLE
Ignore terraform changes to latest_restorable_time

### DIFF
--- a/terraform-v2/cmp.py
+++ b/terraform-v2/cmp.py
@@ -1,9 +1,20 @@
 #!/usr/bin/env python3
 
 import sys
+import re
 
 with open(sys.argv[1], encoding='utf-8') as f:
     first = f.read()
 with open(sys.argv[2], encoding='utf-8') as f:
     second = f.read()
-exit(0 if first.strip() == second.strip() else 1)
+
+# Sanitize AWS computed RDS attribute. See commit message.
+# Other attributes may need to be added in future.
+# Ref: https://github.com/hashicorp/terraform/issues/28803
+first = re.sub(r"(?m)^\s+~ latest_restorable_time\s+=.+$", "", first.strip())
+second = re.sub(r"(?m)^\s+~ latest_restorable_time\s+=.+$", "", second.strip())
+
+if first == second:
+    exit(0)
+
+exit(1)

--- a/terraform-v2/orb_version.txt
+++ b/terraform-v2/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform-v2@2.1.1
+ovotech/terraform-v2@2.2.0


### PR DESCRIPTION
Terraform 0.15.4 starts to report upon the drift changes that have been
detected rather than silently updating its state. One of the attributes
that is now reported includes the latest_restorable_time attribute for RDS
databases.

These drift changes are reported as part of the Terraform plan. Thus,
these changes are also included in the comparison when checking for
approval.

For AWS computed attributes this causes a problem. PITR and database
backups can constantly modify the latest_restorable_time attribute,
meaning that almost every single plan returns a more recent time.
Therefore it's almost impossible for this attribute to ever match what
was in the approved plan, as even if only a few minutes have passed
since the plan was approved the attribute has likely updated again.

We can filter out any lines in the plan that refer to the
latest_restorable_time attribute so that the value mismatch between the
approved plan and the apply-time plan isn't relevant.