### PR TITLE
fix: circle-ci cache-key template needs 2 curly brackets

### DIFF
--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -784,7 +784,7 @@ jobs:
       - save_cache:
           paths:
             - node_modules
-          key: npm-build-dependencies-cache-({checksum "package-lock.json"})
+          key: npm-build-dependencies-cache-{{ checksum "package-lock.json" }}
       - when:
           condition:
             equal: [ "true", $SLACK_INTEGRATION_ENABLED ]
@@ -800,7 +800,7 @@ jobs:
           at: ~/working
       - restore_cache:
           keys:
-            - npm-build-dependencies-cache-({checksum "package-lock.json"})
+            - npm-build-dependencies-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Build docs
           command: npm run build

--- a/jaws-journey-deploy/orb_version.txt
+++ b/jaws-journey-deploy/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/jaws-journey-deploy@1.11.7
+ovotech/jaws-journey-deploy@1.11.8


### PR DESCRIPTION
Noticed the npm build job was always fetching from the cache even when the package-lock.json file had changed. Looks like cache-key template in circleci needs curly brackets. See [here](https://circleci.com/docs/2.0/caching/?utm_medium=SEM&utm_source=gnb&utm_campaign=SEM-gb-DSA-Eng-emea&utm_content=&utm_term=dynamicSearch-&gclid=Cj0KCQjwsZKJBhC0ARIsAJ96n3WWeNgkJ3kMWJm5_ecyTN5gMtl26qbXO4JimB0YSHo1d7pScuAotHIaAoYIEALw_wcB#using-keys-and-templates).