### PR TITLE
ci: update openjdk from legacy CircleCI image to latest version

### DIFF
--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -13,7 +13,7 @@ orbs:
 executors:
   kotlin:
     docker:
-      - image: circleci/openjdk:11.0.7-jdk-buster
+      - image: cimg/openjdk:11.0.12
   python:
     docker:
       - image: circleci/python:3.8

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -16,10 +16,10 @@ executors:
       - image: cimg/openjdk:11.0.12
   python:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
   node:
     docker:
-      - image: circleci/node:14.15.3
+      - image: cimg/node:14.15.3
   terraform:
     docker:
       - image: ovotech/terraform:0.13

--- a/jaws-journey-deploy/orb_version.txt
+++ b/jaws-journey-deploy/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/jaws-journey-deploy@1.11.8
+ovotech/jaws-journey-deploy@1.11.9


### PR DESCRIPTION
As of Dec 31, 2021, legacy images will no longer be supported on CircleCI. Updating OpenJDK, python and node images.

For more information see here: https://circleci.com/docs/2.0/next-gen-migration-guide/