### PR TITLE
terraform v2: disable printing of commands when publishing

### DIFF
--- a/terraform-v2/CHANGELOG.md
+++ b/terraform-v2/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
 not listed
 
+## ovotech/terraform-v2@2.4.2
+- Disabled printing of commands in the publish script
+
 ## ovotech/terraform-v2@2.4.1
 - Add string to match terraform plans on with version 1+
 

--- a/terraform-v2/orb_version.txt
+++ b/terraform-v2/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform-v2@2.4.1
+ovotech/terraform-v2@2.4.2

--- a/terraform-v2/publish.sh
+++ b/terraform-v2/publish.sh
@@ -2,7 +2,6 @@
 
 set -e
 set -o pipefail
-set -x
 
 readonly MODULE_PATH="<< parameters.path >>"
 readonly MODULE_NAME="<< parameters.module_name >>"


### PR DESCRIPTION
I've noticed that CircleCI prints the exact commands that are executed due to the `set -x`. This means that we are printing the presigned URL in plaintext to CircleCI's console. Although the presigned URLs are fairly short-lived, this still contains sensitive information around the S3 bucket; after a brief chat with @eversC, we've agreed to take this out for the publish script while we assess whether we need to keep it for the other commands.