### PR TITLE
[aws-rotate-keys] Default to installing the latest AWS CLI v2 if the binary is not present on the PATH

### DIFF
--- a/aws-rotate-keys/CHANGELOG.md
+++ b/aws-rotate-keys/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
-All notable changes to the orb will be documented in this file.
-Orbs are immutable, some orb versions with no significant changes are
-not listed
+
+All notable changes to the orb will be documented in this file. Orbs are
+immutable, some orb versions with no significant changes are not listed
+
+## ovotech/aws-rotate-keys@2.0.1
+
+- Default to installing the latest version of AWS v2 CLI if the binary is
+  missing from the PATH.
 
 ## ovotech/aws-rotate-keys@2.0.0
- - Updated the orb to use the aws-cli orb v2.
+
+- Updated the orb to use the aws-cli orb v2.
 
 ## ovotech/aws-rotate-keys@1.x.x
+
 - Start of the changelog

--- a/aws-rotate-keys/orb.yml
+++ b/aws-rotate-keys/orb.yml
@@ -30,9 +30,8 @@ commands:
           you will use to hold this value, i.e. AWS_SECRET_ACCESS_KEY.
         default: AWS_SECRET_ACCESS_KEY
     steps:
-      - aws-cli/install:
-          # This only installs the cli if it is missing from $PATH
-          version: '2'
+        # This step only installs the cli if it is missing from the $PATH
+      - aws-cli/install
       - run:
           name: Rotate AWS keys
           command: |

--- a/aws-rotate-keys/orb_version.txt
+++ b/aws-rotate-keys/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/aws-rotate-keys@2.0.0
+ovotech/aws-rotate-keys@2.0.1


### PR DESCRIPTION
This fixes the issue with the version `'2'` that was specified previously which made the job fail if the default executor was used since the install command requires a full version to be specified. I've made it use the latest v2 version by omitting the version parameter.