### PR TITLE
Re-enable terraform orb collapsible plans

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -382,7 +382,7 @@ workflows:
     when: << pipeline.parameters.run-terraform-v2 >>
     jobs:
       - test_python:
-          path: terraform
+          path: terraform-v2
       - validate_orb:
           path: terraform-v2
       - publish_orb:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -71,6 +71,18 @@ parameters:
     default: false
 
 jobs:
+  test_python:
+    description: Tests python code within an orb
+    parameters:
+      path:
+        type: string
+        description: The path to the orb
+    docker:
+      - image: cimg/python:3.9
+    steps:
+      - checkout
+      - run: pip install pytest
+      - run: python -m pytest << parameters.path >>
   validate_orb:
     description: Validate an orb
     parameters:
@@ -357,20 +369,26 @@ workflows:
   terraform:
     when: << pipeline.parameters.run-terraform >>
     jobs:
+      - test_python:
+          path: terraform
       - validate_orb:
           path: terraform
       - publish_orb:
           path: terraform
           requires:
+            - test_python
             - validate_orb
   terraform-v2:
     when: << pipeline.parameters.run-terraform-v2 >>
     jobs:
+      - test_python:
+          path: terraform
       - validate_orb:
           path: terraform-v2
       - publish_orb:
           path: terraform-v2
           requires:
+            - test_python
             - validate_orb
   tools:
     when: << pipeline.parameters.run-tools >>

--- a/terraform-v2/CHANGELOG.md
+++ b/terraform-v2/CHANGELOG.md
@@ -3,8 +3,10 @@ All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
 not listed
 
-## ovotech/terraform-v2@2.4.4
+## ovotech/terraform-v2@2.4.5
+- Reimplements 2.4.3 and fixes bug causing comparing apply-time plan to PR plan to fail
 
+## ovotech/terraform-v2@2.4.4
 - Revert collapsed plans (2.4.3)
 
 ## ovotech/terraform-v2@2.4.3

--- a/terraform-v2/comment_util.py
+++ b/terraform-v2/comment_util.py
@@ -11,7 +11,6 @@ current_template = (
 )
 previous_templates = [
     "```hcl\n{plan}\n```",
-    "```\n{plan}\n```",
 ]
 
 

--- a/terraform-v2/comment_util.py
+++ b/terraform-v2/comment_util.py
@@ -1,19 +1,36 @@
 import re
 
+current_template = (
+    '<details>\n'
+    '<summary>View Terraform Plan</summary>\n\n'
+    '```terraform\n'
+    'Output is limited to 1000 lines and may be truncated. See CircleCI for full details.\n'
+    '{plan}\n'
+    '```\n'
+    '</details>\n'
+)
+previous_templates = [
+    "```hcl\n{plan}\n```",
+    "```\n{plan}\n```",
+]
+
 
 def re_comment_match(comment_id, comment_body):
     """Returns a Match object, or None if no match was found"""
-    m = re.match(rf'{re.escape(comment_id)}\n<details>\n<summary>View Terraform Plan</summary>\n\n'
-                 rf'```terraform\nOutput is limited to 1000 lines and may be truncated\. '
-                 rf'See CircleCI for full details\.\n(.*)\n```\n</details>\n(.*)',
-                 comment_body, re.DOTALL)
-    if m is not None:
-        return m
 
-    return re.match(rf'{re.escape(comment_id)}\n```(?:hcl)?(.*?)```(.*)',
-                    comment_body, re.DOTALL)
+    def _build_regex(template):
+        regex = re.escape(template.replace('{plan}', '___plan___')) \
+            .replace('___plan___', '(.*)')
+        return f'{re.escape(comment_id)}\n{regex}(.*)'
+
+    for tmpl in [current_template, *previous_templates]:
+        m = re.match(_build_regex(tmpl), comment_body, re.DOTALL)
+        if m is not None:
+            return m
+
+    return None
 
 
 def comment_for_pr(comment_id, plan):
     """Returns a formatted string containing comment_id and plan"""
-    return f'{comment_id}\n<details>\n<summary>View Terraform Plan</summary>\n\n```terraform\nOutput is limited to 1000 lines and may be truncated. See CircleCI for full details.\n{plan}\n```\n</details>\n'
+    return f'{comment_id}\n{current_template.format(plan=plan)}'

--- a/terraform-v2/comment_util.py
+++ b/terraform-v2/comment_util.py
@@ -16,4 +16,4 @@ def re_comment_match(comment_id, comment_body):
 
 def comment_for_pr(comment_id, plan):
     """Returns a formatted string containing comment_id and plan"""
-    return f'{comment_id}\n```hcl\n{plan}\n```'
+    return f'{comment_id}\n<details>\n<summary>View Terraform Plan</summary>\n\n```terraform\nOutput is limited to 1000 lines and may be truncated. See CircleCI for full details.\n{plan}\n```\n</details>\n'

--- a/terraform-v2/comment_util.py
+++ b/terraform-v2/comment_util.py
@@ -3,6 +3,13 @@ import re
 
 def re_comment_match(comment_id, comment_body):
     """Returns a Match object, or None if no match was found"""
+    m = re.match(rf'{re.escape(comment_id)}\n<details>\n<summary>View Terraform Plan</summary>\n\n'
+                 rf'```terraform\nOutput is limited to 1000 lines and may be truncated\. '
+                 rf'See CircleCI for full details\.\n(.*)\n```\n</details>\n(.*)',
+                 comment_body, re.DOTALL)
+    if m is not None:
+        return m
+
     return re.match(rf'{re.escape(comment_id)}\n```(?:hcl)?(.*?)```(.*)',
                     comment_body, re.DOTALL)
 

--- a/terraform-v2/orb_version.txt
+++ b/terraform-v2/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform-v2@2.4.4
+ovotech/terraform-v2@2.4.5

--- a/terraform-v2/test_comment_util.py
+++ b/terraform-v2/test_comment_util.py
@@ -4,12 +4,6 @@ import pytest
 
 @pytest.mark.parametrize("comment_id,comment_body,match_group_one,match_group_two",
                          [
-                            #  pre addition of HCL syntax formatting
-                             ("<comment_id>",
-                              "<comment_id>\n```\n<plan>\n```<status>",
-                              "<plan>",
-                              "<status>"
-                             ),
                             #  post addition of HCL syntax formatting
                              ("<comment_id>",
                               "<comment_id>\n```hcl\n<plan>\n```<status>",

--- a/terraform-v2/test_comment_util.py
+++ b/terraform-v2/test_comment_util.py
@@ -16,8 +16,16 @@ import pytest
                               "<plan>",
                               "<status>"
                              ),
+                            #  post addition of collapsible formatting
+                             ("<comment_id>",
+                              "<comment_id>\n<details>\n<summary>View Terraform "
+                              "Plan</summary>\n\n```terraform\nOutput is limited to 1000 lines and may be truncated. "
+                              "See CircleCI for full details.\n<plan>\n```\n</details>\n<status>",
+                              "<plan>",
+                              "<status>"
+                             ),
                           ])
-def test_regex_comment_match(comment_id, comment_body, 
+def test_regex_comment_match(comment_id, comment_body,
                              match_group_one, match_group_two):
     match = comment_util.re_comment_match(comment_id, comment_body)
     assert match.group(1).strip() == match_group_one
@@ -26,4 +34,15 @@ def test_regex_comment_match(comment_id, comment_body,
 
 def test_comment_for_pr():
     comment_for_pr = comment_util.comment_for_pr("<comment_id>", "<plan>")
-    assert comment_for_pr == "<comment_id>\n```hcl\n<plan>\n```"
+    assert comment_for_pr == ("<comment_id>\n<details>\n<summary>View Terraform "
+                              "Plan</summary>\n\n```terraform\nOutput is limited to 1000 lines and may be truncated. "
+                              "See CircleCI for full details.\n<plan>\n```\n</details>\n")
+
+
+def test_comment_match_decodes_comment_for_pr():
+    id = "<comment_id>"
+    plan = "<plan>"
+    comment_for_pr = comment_util.comment_for_pr(id, plan)
+    match = comment_util.re_comment_match(id, comment_for_pr)
+    assert match.group(1).strip() == plan
+    assert match.group(2).strip() == ""

--- a/terraform/CHANGELOG.md
+++ b/terraform/CHANGELOG.md
@@ -3,8 +3,10 @@ All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
 not listed
 
-## ovotech/terraform@1.11.3
+## ovotech/terraform@1.11.4
+- Reimplements release 1.11.2 and fixes bug which caused comparing apply-time plan to PR plan to fail
 
+## ovotech/terraform@1.11.3
 - Revert collapsed plans (1.11.2)
 
 ## ovotech/terraform@1.11.2

--- a/terraform/comment_util.py
+++ b/terraform/comment_util.py
@@ -11,7 +11,6 @@ current_template = (
 )
 previous_templates = [
     "```hcl\n{plan}\n```",
-    "```\n{plan}\n```",
 ]
 
 

--- a/terraform/comment_util.py
+++ b/terraform/comment_util.py
@@ -1,19 +1,36 @@
 import re
 
+current_template = (
+    '<details>\n'
+    '<summary>View Terraform Plan</summary>\n\n'
+    '```terraform\n'
+    'Output is limited to 1000 lines and may be truncated. See CircleCI for full details.\n'
+    '{plan}\n'
+    '```\n'
+    '</details>\n'
+)
+previous_templates = [
+    "```hcl\n{plan}\n```",
+    "```\n{plan}\n```",
+]
+
 
 def re_comment_match(comment_id, comment_body):
     """Returns a Match object, or None if no match was found"""
-    m = re.match(rf'{re.escape(comment_id)}\n<details>\n<summary>View Terraform Plan</summary>\n\n'
-                 rf'```terraform\nOutput is limited to 1000 lines and may be truncated\. '
-                 rf'See CircleCI for full details\.\n(.*)\n```\n</details>\n(.*)',
-                 comment_body, re.DOTALL)
-    if m is not None:
-        return m
 
-    return re.match(rf'{re.escape(comment_id)}\n```(?:hcl)?(.*?)```(.*)',
-                    comment_body, re.DOTALL)
+    def _build_regex(template):
+        regex = re.escape(template.replace('{plan}', '___plan___')) \
+            .replace('___plan___', '(.*)')
+        return f'{re.escape(comment_id)}\n{regex}(.*)'
+
+    for tmpl in [current_template, *previous_templates]:
+        m = re.match(_build_regex(tmpl), comment_body, re.DOTALL)
+        if m is not None:
+            return m
+
+    return None
 
 
 def comment_for_pr(comment_id, plan):
     """Returns a formatted string containing comment_id and plan"""
-    return f'{comment_id}\n<details>\n<summary>View Terraform Plan</summary>\n\n```terraform\nOutput is limited to 1000 lines and may be truncated. See CircleCI for full details.\n{plan}\n```\n</details>\n'
+    return f'{comment_id}\n{current_template.format(plan=plan)}'

--- a/terraform/comment_util.py
+++ b/terraform/comment_util.py
@@ -16,4 +16,4 @@ def re_comment_match(comment_id, comment_body):
 
 def comment_for_pr(comment_id, plan):
     """Returns a formatted string containing comment_id and plan"""
-    return f'{comment_id}\n```hcl\n{plan}\n```'
+    return f'{comment_id}\n<details>\n<summary>View Terraform Plan</summary>\n\n```terraform\nOutput is limited to 1000 lines and may be truncated. See CircleCI for full details.\n{plan}\n```\n</details>\n'

--- a/terraform/comment_util.py
+++ b/terraform/comment_util.py
@@ -3,6 +3,13 @@ import re
 
 def re_comment_match(comment_id, comment_body):
     """Returns a Match object, or None if no match was found"""
+    m = re.match(rf'{re.escape(comment_id)}\n<details>\n<summary>View Terraform Plan</summary>\n\n'
+                 rf'```terraform\nOutput is limited to 1000 lines and may be truncated\. '
+                 rf'See CircleCI for full details\.\n(.*)\n```\n</details>\n(.*)',
+                 comment_body, re.DOTALL)
+    if m is not None:
+        return m
+
     return re.match(rf'{re.escape(comment_id)}\n```(?:hcl)?(.*?)```(.*)',
                     comment_body, re.DOTALL)
 

--- a/terraform/orb_version.txt
+++ b/terraform/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform@1.11.3
+ovotech/terraform@1.11.4

--- a/terraform/test_comment_util.py
+++ b/terraform/test_comment_util.py
@@ -4,12 +4,6 @@ import pytest
 
 @pytest.mark.parametrize("comment_id,comment_body,match_group_one,match_group_two",
                          [
-                            #  pre addition of HCL syntax formatting
-                             ("<comment_id>",
-                              "<comment_id>\n```\n<plan>\n```<status>",
-                              "<plan>",
-                              "<status>"
-                             ),
                             #  post addition of HCL syntax formatting
                              ("<comment_id>",
                               "<comment_id>\n```hcl\n<plan>\n```<status>",

--- a/terraform/test_comment_util.py
+++ b/terraform/test_comment_util.py
@@ -16,6 +16,14 @@ import pytest
                               "<plan>",
                               "<status>"
                              ),
+                            #  post addition of collapsible formatting
+                             ("<comment_id>",
+                              "<comment_id>\n<details>\n<summary>View Terraform "
+                              "Plan</summary>\n\n```terraform\nOutput is limited to 1000 lines and may be truncated. "
+                              "See CircleCI for full details.\n<plan>\n```\n</details>\n<status>",
+                              "<plan>",
+                              "<status>"
+                             ),
                           ])
 def test_regex_comment_match(comment_id, comment_body, 
                              match_group_one, match_group_two):
@@ -26,4 +34,15 @@ def test_regex_comment_match(comment_id, comment_body,
 
 def test_comment_for_pr():
     comment_for_pr = comment_util.comment_for_pr("<comment_id>", "<plan>")
-    assert comment_for_pr == "<comment_id>\n```hcl\n<plan>\n```"
+    assert comment_for_pr == ("<comment_id>\n<details>\n<summary>View Terraform "
+                              "Plan</summary>\n\n```terraform\nOutput is limited to 1000 lines and may be truncated. "
+                              "See CircleCI for full details.\n<plan>\n```\n</details>\n")
+
+
+def test_comment_match_decodes_comment_for_pr():
+    id = "<comment_id>"
+    plan = "<plan>"
+    comment_for_pr = comment_util.comment_for_pr(id, plan)
+    match = comment_util.re_comment_match(id, comment_for_pr)
+    assert match.group(1).strip() == plan
+    assert match.group(2).strip() == ""


### PR DESCRIPTION
This PR fixes the Terraform and Terraform-v2 orbs PR comment matching functionality. The comment matching method wasn't updated when the format of the comment was updated, so the orb became unable to correctly detect plans / update comments on PRs, etc.

It also adds a stage to the CI pipelines for these two orbs to run the existing python tests, so that this problem won't crop up again in the future (hopefully)