### PR TITLE
revert collapsible terraform plans

### DIFF
--- a/terraform-v2/CHANGELOG.md
+++ b/terraform-v2/CHANGELOG.md
@@ -3,8 +3,13 @@ All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
 not listed
 
+## ovotech/terraform-v2@2.4.4
+
+- Revert collapsed plans (2.4.3)
+
 ## ovotech/terraform-v2@2.4.3
 - Plan comments in github PR now appear in a collapsed `<details>` markdown tag which reduces PR comment thread noise (while still being able to view the whole plan if needed)
+
 ## ovotech/terraform-v2@2.4.2
 - Disabled printing of commands in the publish script
 

--- a/terraform-v2/comment_util.py
+++ b/terraform-v2/comment_util.py
@@ -8,5 +8,5 @@ def re_comment_match(comment_id, comment_body):
 
 
 def comment_for_pr(comment_id, plan):
-    """Returns a formatted markdown string containing comment_id and plan"""
-    return f'{comment_id}\n<details>\n<summary>View Terraform Plan</summary>\n\n```terraform\nOutput is limited to 1000 lines and may be truncated. See CircleCI for full details.\n{plan}\n```\n</details>\n'
+    """Returns a formatted string containing comment_id and plan"""
+    return f'{comment_id}\n```hcl\n{plan}\n```'

--- a/terraform-v2/orb_version.txt
+++ b/terraform-v2/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform-v2@2.4.3
+ovotech/terraform-v2@2.4.4

--- a/terraform/CHANGELOG.md
+++ b/terraform/CHANGELOG.md
@@ -3,8 +3,13 @@ All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
 not listed
 
+## ovotech/terraform@1.11.3
+
+- Revert collapsed plans (1.11.2)
+
 ## ovotech/terraform@1.11.2
 - Plan comments in github PR now appear in a collapsed `<details>` markdown tag which reduces PR comment thread noise (while still being able to view the whole plan if needed)
+
 ## ovotech/terraform@1.11.1
 - Add terraform v1 string match for plan operations (`custom_plan.py` exists
   in the executor that's built here in v1 of the orb, so this version bump is

--- a/terraform/comment_util.py
+++ b/terraform/comment_util.py
@@ -9,4 +9,4 @@ def re_comment_match(comment_id, comment_body):
 
 def comment_for_pr(comment_id, plan):
     """Returns a formatted string containing comment_id and plan"""
-    return f'{comment_id}\n<details>\n<summary>View Terraform Plan</summary>\n\n```terraform\nOutput is limited to 1000 lines and may be truncated. See CircleCI for full details.\n{plan}\n```\n</details>\n'
+    return f'{comment_id}\n```hcl\n{plan}\n```'

--- a/terraform/orb_version.txt
+++ b/terraform/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform@1.11.2
+ovotech/terraform@1.11.3


### PR DESCRIPTION
We have identified that 1.11.2/2.4.3 introduced a bug where the Orb is no longer able to pull the plan from a comment, which is used both to determine whether to create or update a comment as well as to compare with the plan from the PR before applying.

While we investigate further, this PR just reverts this functionality so that teams can continue to use the Orb without pinning the version.