### PR TITLE
Add KMI image push job to RaC orb

### DIFF
--- a/rac-gcp-deploy/orb.yml
+++ b/rac-gcp-deploy/orb.yml
@@ -647,10 +647,6 @@ jobs:
 
   push_kmi_docker_image:
     parameters:
-      executor:
-        description: "Name of executor to use for this job. Defaults to docker executor"
-        type: executor
-        default: docker
       workspace-dir:
         description: "Path to restore/save the workspace"
         type: string
@@ -671,7 +667,8 @@ jobs:
         description: "The KMI namespace this container is deployed into. Defaults to the container name"
         type: env_var_name
         default: CIRCLE_PROJECT_REPONAME
-    executor: <<parameters.executor>>
+    docker:
+      - image: cimg/openjdk:11.0.13 # Supports the AWS CLI
     steps:
       - setup_remote_docker
       - restore_workspace:

--- a/rac-gcp-deploy/orb.yml
+++ b/rac-gcp-deploy/orb.yml
@@ -16,6 +16,7 @@ aliases:
 
 orbs:
   snyk: snyk/snyk@0.0.13
+  aws-ecr: circleci/aws-ecr@7.2.0
 
 executors:
   machine:
@@ -643,6 +644,49 @@ jobs:
       - snyk_monitor
       - persist_workspace:
           to: <<parameters.workspace-dir>>
+
+  push_kmi_docker_image:
+    parameters:
+      executor:
+        description: "Name of executor to use for this job. Defaults to docker executor"
+        type: executor
+        default: docker
+      workspace-dir:
+        description: "Path to restore/save the workspace"
+        type: string
+        default: ~/project
+      container-name:
+        description: "Name of environment variable storing the name of the container we are publishing"
+        type: env_var_name
+        default: CIRCLE_PROJECT_REPONAME
+      gcr-registry-url:
+        description: "The GCR registry URL. Defaults to eu.gcr.io"
+        default: eu.gcr.io
+        type: string
+      kmi-registry-url:
+        description: "The URL of the centralised ECR registry"
+        type: env_var_name
+        default: AWS_ECR_ACCOUNT_URL
+      kmi-namespace:
+        description: "The KMI namespace this container is deployed into. Defaults to the container name"
+        type: env_var_name
+        default: CIRCLE_PROJECT_REPONAME
+    executor: <<parameters.executor>>
+    steps:
+      - setup_remote_docker
+      - restore_workspace:
+          to: <<parameters.workspace-dir>>
+      - run:
+          name: "Load docker image from file and tag"
+          command: |
+            export NONPROD_IMAGE_ROOT=<<parameters.gcr-registry-url>>/randc-nonprod/$<<parameters.container-name>>
+            docker load -i <<parameters.workspace-dir>>/$<<parameters.container-name>>.dockerimage
+            docker tag "${NONPROD_IMAGE_ROOT}:$(cat version.txt)" $<<parameters.kmi-registry-url>>/$<<parameters.kmi-namespace>>/$<<parameters.container-name>>:$(cat version.txt)
+      - aws-ecr/ecr-login
+      - run:
+          name: "Push docker image to KMI registry"
+          command: |
+            docker push $<<parameters.kmi-registry-url>>/$<<parameters.kmi-namespace>>/$<<parameters.container-name>>:$(cat version.txt)
 
   push_docker_image:
     parameters:


### PR DESCRIPTION
This adds a new job to the R&C orb, to push an image to the centralised image registry where it can be pulled in by KMI. The AWS_ECR_ACCOUNT_URL and AWS_REGION environment variables have already been added to the main R&C context but the AWS image pushing credentials will need to be added per service, as they are different for each namespace.

I have not added this new job to the README as the image pushing jobs don't seem to be in there and I wanted to double check if this is a deliberate choice, given the orb is public?

I'm also not sure how to increase the version for this orb, as I can't see an orb_version.txt file?