### PR TITLE
RNC-2456 Add KMI deployment step to RAC orb

### DIFF
--- a/rac-gcp-deploy/README.md
+++ b/rac-gcp-deploy/README.md
@@ -47,7 +47,7 @@ This job will bundle the service into a docker image and publish the generated i
 - `executor` - : Name of executor to use for this job. Defaults to `docker` executor.
 - `workspace-dir` - Path to restore/save the workspace. Defaults to `~/project`.
 - `git-username` - Name of the environment variable storing the git username. Defaults to `GIT_USERNAME`.
-- `git_user_email` - Name of the environment variable storing the email of the github user to use when pushing commits. Defaults to `GIT_USER_EMAIL`.
+- `git-user-email` - Name of the environment variable storing the email of the github user to use when pushing commits. Defaults to `GIT_USER_EMAIL`.
 - `ssh-key-fingerprint` - The fingerprint of the ssh key with permissions to checkout.
 - `google-cloud-sdk-version` - The version of google cloud sdk to install. Defaults to `246.0.0-0`.
 - `google-compute-zone` - The Google compute zone to connect with via the gcloud CLI. Defaults to `europe-west1-b`.

--- a/rac-gcp-deploy/orb.yml
+++ b/rac-gcp-deploy/orb.yml
@@ -463,7 +463,7 @@ jobs:
         description: "Name of the environment variable storing the github user to use when pushing commits"
         type: env_var_name
         default: GIT_USERNAME
-      git_user_email:
+      git-user-email:
         description: "Name of the environment variable storing the email of the github user to use when pushing commits"
         type: env_var_name
         default: GIT_USER_EMAIL
@@ -523,7 +523,7 @@ jobs:
             mkdir -p -m 0700 ~/.ssh/
             ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
             git config --global user.name "$<<parameters.git-username>>"
-            git config --global user.email "$<<parameters.git_user_email>>"
+            git config --global user.email "$<<parameters.git-user-email>>"
       - add_ssh_keys:
           fingerprints:
             - <<parameters.ssh-key-fingerprint>>
@@ -597,7 +597,7 @@ jobs:
         description: "Name of the environment variable storing the github user to use when pushing commits"
         type: env_var_name
         default: GIT_USERNAME
-      git_user_email:
+      git-user-email:
         description: "Name of the environment variable storing the email of the github user to use when pushing commits"
         type: env_var_name
         default: GIT_USER_EMAIL
@@ -629,7 +629,7 @@ jobs:
             mkdir -p -m 0700 ~/.ssh/
             ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
             git config --global user.name "$<<parameters.git-username>>"
-            git config --global user.email "$<<parameters.git_user_email>>"
+            git config --global user.email "$<<parameters.git-user-email>>"
       - add_ssh_keys:
           fingerprints:
             - <<parameters.ssh-key-fingerprint>>
@@ -783,7 +783,7 @@ jobs:
         description: "Name of the environment variable storing the github user to use when pushing commits"
         type: env_var_name
         default: GIT_USERNAME
-      git_user_email:
+      git-user-email:
         description: "Name of the environment variable storing the email of the github user to use when pushing commits"
         type: env_var_name
         default: GIT_USER_EMAIL
@@ -806,7 +806,7 @@ jobs:
           name: Commit and push
           command: |
             cd  ~/gitops
-            git config user.email "$<<parameters.git_user_email>>"
+            git config user.email "$<<parameters.git-user-email>>"
             git config user.name "$<<parameters.git-username>>"
             git add .
             if [ -z "$(git status --porcelain)" ]; then
@@ -830,7 +830,7 @@ jobs:
         description: "Name of the environment variable storing the github user to use when pushing commits"
         type: env_var_name
         default: GIT_USERNAME
-      git_user_email:
+      git-user-email:
         description: "Name of the environment variable storing the email of the github user to use when pushing commits"
         type: env_var_name
         default: GIT_USER_EMAIL
@@ -869,7 +869,7 @@ jobs:
             mkdir -p -m 0700 ~/.ssh/
             ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
             git config --global user.name "$<<parameters.git-username>>"
-            git config --global user.email "$<<parameters.git_user_email>>"
+            git config --global user.email "$<<parameters.git-user-email>>"
       - add_ssh_keys:
           fingerprints:
             - <<parameters.ssh-key-fingerprint>>

--- a/rac-gcp-deploy/orb.yml
+++ b/rac-gcp-deploy/orb.yml
@@ -773,6 +773,7 @@ jobs:
         default: CIRCLE_PROJECT_REPONAME
       kmi-env:
         description: "The environment of KMI to deploy to"
+        type: string
         default: uat
       git-username:
         description: "Name of the environment variable storing the github user to use when pushing commits"
@@ -810,7 +811,7 @@ jobs:
             if [ -z "$(git status --porcelain)" ]; then
               echo "No changes detected."
             else
-              git commit -m "Bumping $<<parameters.container-name>> image tag to ${CONTAINER_VERSION}"
+              git commit -m "Bumping $<<parameters.container-name>> image tag to ${CONTAINER_VERSION} for <<parameters.kmi-env>>"
               git push origin main
             fi
 

--- a/rac-gcp-deploy/orb.yml
+++ b/rac-gcp-deploy/orb.yml
@@ -805,6 +805,8 @@ jobs:
       - run: 
           name: Set version as environment variable
           command: |
+            ls .
+            ls <<parameters.workspace-dir>>
             export CONTAINER_VERSION=$(cat version.txt)
       - run:
           name: Clone gitops repo

--- a/rac-gcp-deploy/orb.yml
+++ b/rac-gcp-deploy/orb.yml
@@ -765,6 +765,56 @@ jobs:
             IMAGE_ROOT=<<parameters.registry-url>>/$<<parameters.gcp-project-id>>/$<<parameters.container-name>>
             docker push "${IMAGE_ROOT}"
 
+  deploy_to_kmi:
+    parameters:
+      container-name:
+        description: "Name of environment variable storing the name of the container we are publishing"
+        type: env_var_name
+        default: CIRCLE_PROJECT_REPONAME
+      kmi-env:
+        description: "The environment of KMI to deploy to"
+        default: uat
+      git-username:
+        description: "Name of the environment variable storing the github user to use when pushing commits"
+        type: env_var_name
+        default: GIT_USERNAME
+      git_user_email:
+        description: "Name of the environment variable storing the email of the github user to use when pushing commits"
+        type: env_var_name
+        default: GIT_USER_EMAIL
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      - run: 
+          name: Set version as environment variable
+          command: |
+            export CONTAINER_VERSION=$(cat version.txt)
+      - run:
+          name: Clone gitops repo
+          command: |
+            rm -rf ~/gitops
+            git clone https://$GITHUB_TOKEN@github.com/ovotech/rac-kmi-gitops ~/gitops
+      - run:
+          name: Patch deployment
+          command: |
+            cd ~/gitops/$<<parameters.container-name>>
+            yq e ".version=\"${CONTAINER_VERSION}\"" -i values-<<parameters.kmi-env>>-shared.yaml
+      - run:
+          name: Commit and push
+          command: |
+            cd  ~/gitops
+            git config user.email "$<<parameters.git_user_email>>"
+            git config user.name "$<<parameters.git-username>>"
+            git add .
+            if [ -z "$(git status --porcelain)" ]; then
+              echo "No changes detected."
+            else
+              git commit -m "Bumping $<<parameters.container-name>> image tag to ${CONTAINER_VERSION}"
+              git push origin main
+            fi
+
+
   release_library:
     parameters:
       executor:

--- a/rac-gcp-deploy/orb.yml
+++ b/rac-gcp-deploy/orb.yml
@@ -787,27 +787,11 @@ jobs:
         description: "Name of the environment variable storing the email of the github user to use when pushing commits"
         type: env_var_name
         default: GIT_USER_EMAIL
-      cache-key:
-        type: string
-        default: *cache-key
-      cache-suffix:
-        description: "Suffix to use for the cache key, e.g. -v2, to be able to clear the cache"
-        default: ""
-        type: string
     docker:
       - image: cimg/base:stable
     steps:
       - restore_workspace:
           to: <<parameters.workspace-dir>>
-      - load_cache:
-          cache-key: <<parameters.cache-key>>
-          cache-suffix: <<parameters.cache-suffix>>
-      - run: 
-          name: Set version as environment variable
-          command: |
-            ls .
-            ls <<parameters.workspace-dir>>
-            export CONTAINER_VERSION=$(cat version.txt)
       - run:
           name: Clone gitops repo
           command: |
@@ -817,7 +801,7 @@ jobs:
           name: Patch deployment
           command: |
             cd ~/gitops/$<<parameters.container-name>>
-            yq e ".version=\"${CONTAINER_VERSION}\"" -i values-<<parameters.kmi-env>>-shared.yaml
+            yq e ".version=\"$(cat <<parameters.workspace-dir>>/version.txt)\"" -i values-<<parameters.kmi-env>>-shared.yaml
       - run:
           name: Commit and push
           command: |
@@ -828,10 +812,9 @@ jobs:
             if [ -z "$(git status --porcelain)" ]; then
               echo "No changes detected."
             else
-              git commit -m "Bumping $<<parameters.container-name>> image tag to ${CONTAINER_VERSION} for <<parameters.kmi-env>>"
+              git commit -m "Bumping $<<parameters.container-name>> image tag to $(cat <<parameters.workspace-dir>>/version.txt) for <<parameters.kmi-env>>"
               git push origin main
             fi
-
 
   release_library:
     parameters:

--- a/rac-gcp-deploy/orb.yml
+++ b/rac-gcp-deploy/orb.yml
@@ -767,6 +767,10 @@ jobs:
 
   deploy_to_kmi:
     parameters:
+      workspace-dir:
+        description: "Path to restore/save the workspace"
+        type: string
+        default: ~/project
       container-name:
         description: "Name of environment variable storing the name of the container we are publishing"
         type: env_var_name
@@ -783,10 +787,21 @@ jobs:
         description: "Name of the environment variable storing the email of the github user to use when pushing commits"
         type: env_var_name
         default: GIT_USER_EMAIL
+      cache-key:
+        type: string
+        default: *cache-key
+      cache-suffix:
+        description: "Suffix to use for the cache key, e.g. -v2, to be able to clear the cache"
+        default: ""
+        type: string
     docker:
       - image: cimg/base:stable
     steps:
-      - checkout
+      - restore_workspace:
+          to: <<parameters.workspace-dir>>
+      - load_cache:
+          cache-key: <<parameters.cache-key>>
+          cache-suffix: <<parameters.cache-suffix>>
       - run: 
           name: Set version as environment variable
           command: |


### PR DESCRIPTION
This commits the new version tag to the rac-kmi-gitops repo, kicking off a deployment in KMI.