### PR TITLE
Add Helm CI orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ workflows:
             clojure/.* run-clojure true
             comms-commands/.* run-comms-commands true
             gcp-rotate-keys/.* run-gcp-rotate-keys true
+            helm-ci/.* run-helm-ci true
             jaws-journey-deploy/.* run-jaws-journey-deploy true
             oot-deploy/.* run-oot-deploy true
             oot-eks/.* run-oot-eks true

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -297,6 +297,15 @@ workflows:
           path: gcp-rotate-keys
           requires:
             - validate_orb
+  helm-ci:
+    when: << pipeline.parameters.run-helm-ci >>
+    jobs:
+      - validate_orb:
+          path: helm-ci
+      - publish_orb:
+          path: helm-ci
+          requires:
+            - validate_orb
   jaws-journey-deploy:
     when: << pipeline.parameters.run-jaws-journey-deploy >>
     jobs:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -27,6 +27,9 @@ parameters:
   run-gcp-rotate-keys:
     type: boolean
     default: false
+  run-helm-ci:
+    type: boolean
+    default: false
   run-jaws-journey-deploy:
     type: boolean
     default: false

--- a/helm-ci/README.md
+++ b/helm-ci/README.md
@@ -8,7 +8,7 @@ Provides CI functionality for working with Helm.
 
 ```yaml
 orbs:
-  helm-ci: ovotech/helm@-ci0.0.1
+  helm-ci: ovotech/helm-ci@0.0.1
 
 workflows:
   commit:

--- a/helm-ci/README.md
+++ b/helm-ci/README.md
@@ -8,10 +8,12 @@ Provides CI functionality for working with Helm.
 
 ```yaml
 orbs:
-  helm: ovotech/helm@-ci0.0.1
+  helm-ci: ovotech/helm@-ci0.0.1
 
-jobs:
-  helm/lint-chart:
-    chart_path: <path/to/helm/chart>
-    values_files: <values-file.yaml>,<other-values-file.yaml>
+workflows:
+  commit:
+    jobs:
+      - helm-ci/lint-chart:
+          chart_path: <path/to/helm/chart>
+          values_files: <values-file.yaml>,<other-values-file.yaml>
 ```

--- a/helm-ci/README.md
+++ b/helm-ci/README.md
@@ -1,0 +1,17 @@
+# Helm CI Orb
+
+Provides CI functionality for working with Helm.
+
+## Example Usage
+
+### lint-chart
+
+```yaml
+orbs:
+  helm: ovotech/helm@-ci0.0.1
+
+jobs:
+  helm/lint-chart:
+    chart_path: <path/to/helm/chart>
+    values_files: <values-file.yaml>,<other-values-file.yaml>
+```

--- a/helm-ci/executor/Dockerfile
+++ b/helm-ci/executor/Dockerfile
@@ -1,6 +1,0 @@
-# The docker image produced by this is intended for use by the helm-ci circleCI orb.
-FROM alpine/helm:3.7.2
-
-RUN wget https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz
-RUN tar xf kubeval-linux-amd64.tar.gz
-RUN cp kubeval /usr/local/bin

--- a/helm-ci/executor/Dockerfile
+++ b/helm-ci/executor/Dockerfile
@@ -1,0 +1,6 @@
+# The docker image produced by this is intended for use by the helm-ci circleCI orb.
+FROM alpine/helm:3.7.2
+
+RUN wget https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz
+RUN tar xf kubeval-linux-amd64.tar.gz
+RUN cp kubeval /usr/local/bin

--- a/helm-ci/orb.yml
+++ b/helm-ci/orb.yml
@@ -2,9 +2,9 @@ version: 2.1
 description: "Defines jobs for CI with Helm"
 
 executors:
-  helm-ci:
+  default:
     docker:
-      - image: ovotech/helm-ci:add-helm-orb_23-12-2021
+      - image: alpine/helm:3.7.2
 
 commands:
   lint-chart:
@@ -28,11 +28,14 @@ commands:
             helm template -f <<parameters.values_files>> <<parameters.chart_path>> > output.yaml
       - run:
           name: "Run kubeval over helm output"
-          command: kubeval --ignore-missing-schemas output.yaml
+          command: |
+            wget https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-linux-amd64.tar.gz
+            tar xf kubeval-linux-amd64.tar.gz
+            ./kubeval --ignore-missing-schemas output.yaml
 
 jobs:
   lint-chart:
-    executor: helm-ci
+    executor: default
     parameters:
       chart_path:
         type: string

--- a/helm-ci/orb.yml
+++ b/helm-ci/orb.yml
@@ -43,4 +43,4 @@ jobs:
     steps: 
       - lint-chart:
           chart_path: << parameters.chart_path >>
-          values_files: << <parameters.values_files >>
+          values_files: << parameters.values_files >>

--- a/helm-ci/orb.yml
+++ b/helm-ci/orb.yml
@@ -1,0 +1,46 @@
+version: 2.1
+description: "Defines jobs for CI with Helm"
+
+executors:
+  helm-ci:
+    docker:
+      - image: ovotech/helm-ci:latest
+
+commands:
+  lint-chart:
+    description: "Runs helm lint and kubeval over a helm chart"
+    parameters:
+      chart_path:
+        type: string
+        description: "Path to the helm chart to lint"
+      values_files:
+        type: string
+        description: "CSV of values files to pass to helm chart when templating to run kubeval"
+    steps:
+      - checkout
+      - run:
+          name: "Lint chart"
+          command: helm lint -f <<parameters.values_files>> <<parameters.chart_path>>
+      - run:
+          name: "Template chart"
+          command: |
+            rm -f output.yaml
+            helm template -f <<parameters.values_files>> <<parameters.chart_path>> > output.yaml
+      - run:
+          name: "Run kubeval over helm output"
+          command: kubeval --ignore-missing-schemas output.yaml
+
+jobs:
+  lint-chart:
+    executor: helm-ci
+    parameters:
+      chart_path:
+        type: string
+        description: "Path to the helm chart to lint"
+      values_files:
+        type: string
+        description: "Values files to pass to helm chart when templating to run kubeval"
+    steps: 
+      - lint-chart:
+          chart_path: << parameters.chart_path >>
+          values_files: << <parameters.values_files >>

--- a/helm-ci/orb.yml
+++ b/helm-ci/orb.yml
@@ -4,7 +4,7 @@ description: "Defines jobs for CI with Helm"
 executors:
   helm-ci:
     docker:
-      - image: ovotech/helm-ci:latest
+      - image: ovotech/helm-ci:add-helm-orb_23-12-2021
 
 commands:
   lint-chart:

--- a/helm-ci/orb_version.txt
+++ b/helm-ci/orb_version.txt
@@ -1,0 +1,1 @@
+ovotech/helm@0.0.1


### PR DESCRIPTION
Teams moving to KMI are being encouraged to use helm in their gitops repositories. I'm finding there's a lot of duplication in the CI for those gitops repositories and there doesn't seem to be a good open source circleCI orb for Helm CI, so creating one.

This is quite focused on the KMI use-case - e.g. it assumes you will have values files associated with the chart and no values being passed in directly in the helm templating step. I think this is acceptable for a first version of the orb and we can add parameterisation for other use cases in future.

https://app.circleci.com/pipelines/github/ovotech/energy-contracts-kmi-gitops/104/workflows/f0ca0afe-3d3e-4c54-9e6b-2faca77a8e7b/jobs/187 is an example of the orb running.