### PR TITLE
Parameter to override default snyk token env variable

### DIFF
--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -191,6 +191,9 @@ commands:
       token:
         type: string
         default: $GITHUB_BOT_PACKAGE_MANAGER_TOKEN
+      snyk-token:
+        type: env_var_name
+        default: SNYK_TOKEN
       <<: *resourceClass
       <<: *parallelism
     steps:
@@ -254,6 +257,7 @@ commands:
                 project: << parameters.serviceName >>
                 severity-threshold: high
                 target-file: ./<< parameters.serviceName >>/Dockerfile
+                token-variable: << parameters.snyk-token >>
       - when:
           condition:
             equal: [ "true", $SLACK_INTEGRATION_ENABLED ]

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -257,7 +257,7 @@ commands:
                 project: << parameters.serviceName >>
                 severity-threshold: high
                 target-file: ./<< parameters.serviceName >>/Dockerfile
-                token-variable: << parameters.snyk-token >>
+                token-variable: << parameters.snyk_token >>
       - when:
           condition:
             equal: [ "true", $SLACK_INTEGRATION_ENABLED ]

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -805,6 +805,10 @@ jobs:
                 region: AWS_DEFAULT_REGION
                 repo: << parameters.serviceName >>
                 tag: "latest,$CIRCLE_SHA1"
+            - run:
+                name: echo
+                command: |
+                  echo $MARS_SNYK_TOKEN
             - snyk/scan:
                 docker-image-name: $AWS_ACCOUNT_URL/<< parameters.serviceName >>:latest
                 fail-on-issues: true

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -672,6 +672,9 @@ jobs:
       token:
         type: string
         default: $GITHUB_BOT_PACKAGE_MANAGER_TOKEN
+      snyk_token:
+        type: env_var_name
+        default: SNYK_TOKEN
       <<: *resourceClass
       <<: *parallelism
     parallelism: << parameters.parallelism >>
@@ -705,6 +708,7 @@ jobs:
           project: << parameters.serviceName >>
           severity-threshold: high
           target-file: ./<< parameters.serviceName >>/Dockerfile
+          token-variable: << parameters.snyk_token >>
       - when:
           condition:
             equal: [ "true", $SLACK_INTEGRATION_ENABLED ]
@@ -738,6 +742,9 @@ jobs:
       token:
         type: string
         default: $GITHUB_BOT_PACKAGE_MANAGER_TOKEN
+      snyk_token:
+        type: env_var_name
+        default: SNYK_TOKEN
       <<: *resourceClass
       <<: *parallelism
     parallelism: << parameters.parallelism >>
@@ -805,6 +812,7 @@ jobs:
                 project: << parameters.serviceName >>
                 severity-threshold: high
                 target-file: ./<< parameters.serviceName >>/Dockerfile
+                token-variable: << parameters.snyk_token >>
       - when:
           condition:
             equal: [ "true", $SLACK_INTEGRATION_ENABLED ]

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -191,7 +191,7 @@ commands:
       token:
         type: string
         default: $GITHUB_BOT_PACKAGE_MANAGER_TOKEN
-      snyk-token:
+      snyk_token:
         type: env_var_name
         default: SNYK_TOKEN
       <<: *resourceClass

--- a/jaws-journey-deploy/orb_version.txt
+++ b/jaws-journey-deploy/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/jaws-journey-deploy@1.11.18
+ovotech/jaws-journey-deploy@1.11.19


### PR DESCRIPTION
Reason for this is we have a service using the JAWS circleci contexts but we want to move it to the MARS Synk org