### PR TITLE
update to cimg image

### DIFF
--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -450,9 +450,7 @@ commands:
   report-code-coverage:
     description: "Add code coverage report"
     steps:
-      - run:
-          name: "Install python dependencies"
-          command: pip3 install --upgrade requests
+      - install-python-dependencies
       - run:
           name: "Report code coverage"
           shell: /bin/bash -eo pipefail
@@ -462,14 +460,21 @@ commands:
   topology-describe:
     description: "Upload topology diagram to GH as a comment"
     steps:
-      - run:
-          name: "Install python dependencies"
-          command: pip3 install --upgrade requests
+      - install-python-dependencies
       - run:
           name: "Upload topology diagram to GH as a comment"
           shell: /bin/bash -eo pipefail
           command: |
             include ./scripts/topology_comment.sh
+
+  install-python-dependencies:
+    description: "Install python dependencies"
+    steps:
+      - run:
+          name: "Install python dependencies"
+          command: |
+            pip3 install --upgrade pip
+            pip3 install requests
 
   install-adoptopenjdk:
     description: "Install adoptopenjdk"
@@ -1000,9 +1005,7 @@ jobs:
                 command: |   
                   echo 'export ARGOCD_TOKEN="<< parameters.argocd_token >>"' >> $BASH_ENV
                   cat /tmp/argocd/env >> $BASH_ENV
-            - run:
-                name: "Install python dependencies"
-                command: pip3 install --upgrade requests
+            - install-python-dependencies
             - argocd/wait_for_sync:
                 application: $CIRCLE_PROJECT_REPONAME
                 argocd_url: << parameters.argocd_url >>

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -452,7 +452,7 @@ commands:
     steps:
       - run:
           name: "Install python dependencies"
-          command: pip3 install requests
+          command: pip3 install --upgrade requests
       - run:
           name: "Report code coverage"
           shell: /bin/bash -eo pipefail
@@ -462,6 +462,9 @@ commands:
   topology-describe:
     description: "Upload topology diagram to GH as a comment"
     steps:
+      - run:
+          name: "Install python dependencies"
+          command: pip3 install --upgrade requests
       - run:
           name: "Upload topology diagram to GH as a comment"
           shell: /bin/bash -eo pipefail

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -16,7 +16,7 @@ executors:
       - image: cimg/openjdk:11.0.12
   python:
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
   node:
     docker:
       - image: cimg/node:14.17.3

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -1000,6 +1000,9 @@ jobs:
                 command: |   
                   echo 'export ARGOCD_TOKEN="<< parameters.argocd_token >>"' >> $BASH_ENV
                   cat /tmp/argocd/env >> $BASH_ENV
+            - run:
+                name: "Install python dependencies"
+                command: pip3 install --upgrade requests
             - argocd/wait_for_sync:
                 application: $CIRCLE_PROJECT_REPONAME
                 argocd_url: << parameters.argocd_url >>

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -16,7 +16,7 @@ executors:
       - image: cimg/openjdk:11.0.12
   python:
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.8.0
   node:
     docker:
       - image: cimg/node:14.17.3

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -451,6 +451,9 @@ commands:
     description: "Add code coverage report"
     steps:
       - run:
+          name: "Install python dependencies"
+          command: pip3 install requests
+      - run:
           name: "Report code coverage"
           shell: /bin/bash -eo pipefail
           command: |

--- a/jaws-journey-deploy/orb_version.txt
+++ b/jaws-journey-deploy/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/jaws-journey-deploy@1.11.18
+ovotech/jaws-journey-deploy@1.11.19


### PR DESCRIPTION
Legacy circleci python images are being deprecated. so moving to `cimg` images. Having to install the `requests` module
https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034