### PR TITLE
Add datadog tags on deployments

### DIFF
--- a/asp-deploy/orb.yml
+++ b/asp-deploy/orb.yml
@@ -61,6 +61,7 @@ commands:
             TAG=<<parameters.image-tag>>
             cd  ~/gitops/<<parameters.env>>
             kustomize edit set image $(echo <<parameters.service-name>> | tr a-z A-Z)=${<<parameters.aws-account-url>>}/<<parameters.service-name>>-<<parameters.env>>:$TAG
+            sed "s/tags.datadoghq.com\/version: .*/tags.datadoghq.com\/version: $TAG/g" general/patches/<<parameters.service-name>>.yaml || echo "No file to replace tag, continuing..."
       - run:
           name: Commit and push
           command: |

--- a/asp-deploy/orb.yml
+++ b/asp-deploy/orb.yml
@@ -61,7 +61,7 @@ commands:
             TAG=<<parameters.image-tag>>
             cd  ~/gitops/<<parameters.env>>
             kustomize edit set image $(echo <<parameters.service-name>> | tr a-z A-Z)=${<<parameters.aws-account-url>>}/<<parameters.service-name>>-<<parameters.env>>:$TAG
-            sed "s/tags.datadoghq.com\/version: .*/tags.datadoghq.com\/version: $TAG/g" general/patches/<<parameters.service-name>>.yaml || echo "No file to replace tag, continuing..."
+            sed -i "s/tags.datadoghq.com\/version: .*/tags.datadoghq.com\/version: $TAG/g" general/patches/<<parameters.service-name>>.yaml || echo "No file to replace tag, continuing..."
       - run:
           name: Commit and push
           command: |


### PR DESCRIPTION
Add a sed to replace the tag on the kustomize patch files, this way updating the datadog version on the deployment step.