### PR TITLE
Update image for machine executor

### DIFF
--- a/rac-gcp-deploy/orb.yml
+++ b/rac-gcp-deploy/orb.yml
@@ -20,7 +20,8 @@ orbs:
 
 executors:
   machine:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
   docker:
     docker:
       - image: ovotech/rac-gcp-deploy:latest


### PR DESCRIPTION
Older images will soon be deprecated by CircleCi
https://circleci.com/blog/ubuntu-14-16-image-deprecation/