### PR TITLE
fix: update snyk orb

### DIFF
--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -5,7 +5,7 @@ orbs:
   aws-ecr: circleci/aws-ecr@7.0.0
   terraform: ovotech/terraform@1.8.2
   openjdk-install: cloudesire/openjdk-install@1.2.3
-  snyk: snyk/snyk@0.0.10
+  snyk: snyk/snyk@1.1.2
   shipit: ovotech/shipit@1
   slack: circleci/slack@4.1.3
   argocd: ovotech/argocd@1.0.2

--- a/jaws-journey-deploy/orb_version.txt
+++ b/jaws-journey-deploy/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/jaws-journey-deploy@1.11.21
+ovotech/jaws-journey-deploy@1.11.22


### PR DESCRIPTION
The download link got changed a while ago
https://github.com/snyk/snyk-orb/commit/46f6fa5ca3a7e782d2b22ff19bc4920827b5f530
So bumping to snyk/snyk@1.1.2