### PR TITLE
Bump docker ubuntu image to 20.04

### DIFF
--- a/oot-eks/orb.yml
+++ b/oot-eks/orb.yml
@@ -72,6 +72,4 @@ commands:
 executors:
   aws:
     machine:
-      image: ubuntu-1604:202010-01
-
-
+      image: ubuntu-2004:202201-02


### PR DESCRIPTION
Bumping oot eks docker image from 16 to 20.04

https://circleci.com/blog/ubuntu-14-16-image-deprecation/