### PR TITLE
fix: updating code coverage link

### DIFF
--- a/jaws-journey-deploy/orb_version.txt
+++ b/jaws-journey-deploy/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/jaws-journey-deploy@1.11.23
+ovotech/jaws-journey-deploy@1.11.24

--- a/jaws-journey-deploy/scripts/get_coverage.py
+++ b/jaws-journey-deploy/scripts/get_coverage.py
@@ -41,7 +41,7 @@ class CoverageComment:
                     branches, branches_covered = self.get_stats(branches, branches_covered, row, BRANCH_COVERED, BRANCH_MISSED)
 
                 filename = self.get_filename(report, '.csv')
-                url = self.create_url(f'{filename.replace(":", "%3A")}/html/index.html')
+                url = self.create_url(f'{filename.replace(":", "%3A")}/index.html')
                 self._comment += self.create_line(filename, url,
                                                   self.calc_percentage(instructions_covered, instructions),
                                                   self.calc_percentage(branches_covered, branches))


### PR DESCRIPTION
In a PR if you click on the code coverage links for a particular project it will show `Artifact not found`