### PR TITLE
Add publish to KMI ECR command to JAWS deploy orb

### DIFF
--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -29,7 +29,7 @@ aliases:
     environment: &environment
       environment:
         type: "enum"
-        enum: ["sandbox", "test", "uat", "nonprod", "prod"]
+        enum: ["sandbox", "test", "uat", "nonprod", "prod", "undefined"]
         default: "sandbox"
     serviceName: &serviceName
       serviceName:
@@ -1058,6 +1058,7 @@ jobs:
                 application: $CIRCLE_PROJECT_REPONAME
                 argocd_url: << parameters.argocd_url >>
                 target: $ARGOCD_TARGET_REVISION
+  
   run-automation-test:
     parameters:
       <<: *environment
@@ -1102,7 +1103,6 @@ jobs:
           steps:
             - slack/notify:
                 <<: *slack-notification
-
 
   topology-describe:
     executor: python

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -688,6 +688,15 @@ jobs:
 
   publish-image-kmi:
     parameters:
+      privateDockerImage: 
+        type: boolean
+        default: false
+      username:
+        type: string
+        default: $GITHUB_BOT_USERNAME
+      token:
+        type: string
+        default: $GITHUB_BOT_PACKAGE_MANAGER_TOKEN
       namespace:
         type: string
       application:
@@ -695,15 +704,39 @@ jobs:
       sandboxIdentifier:
         type: string
         default: ""
-      <<: *image
-    machine:
-      docker_layer_caching: false
-      image: << parameters.image >>
+      serviceName:
+        type: string
+        default: << parameters.application >>-service
+      <<: *resourceClass
+      <<: *parallelism
+    parallelism: << parameters.parallelism >>
+    resource_class: << parameters.resourceClass >>
+    executor: kotlin
+    working_directory: ~/working
     steps:
-      - aws-ecr/ecr-login
-      - aws-ecr/push-image:
+      - attach_workspace:
+          at: ~/working
+      - when:
+          condition:
+            equal: [ "true", << parameters.privateDockerImage >> ]
+          steps:
+            - github-repo-login:
+                username: << parameters.username >>
+                token: << parameters.token >>
+      - aws-ecr/build-and-push-image:
+          setup-remote-docker: true
+          checkout: false
+          path: ./<< parameters.serviceName >>
+          create-repo: false
           repo: << parameters.namespace >>/<< parameters.application >><< parameters.sandboxIdentifier >>
           tag: '${CIRCLE_SHA1}'
+      - snyk/scan:
+          docker-image-name: $AWS_ACCOUNT_URL/<< parameters.namespace >>/<< parameters.application >><< parameters.sandboxIdentifier >>:$CIRCLE_SHA1
+          fail-on-issues: true
+          monitor-on-build: true
+          project: << parameters.namespace >>-<< parameters.application >>
+          severity-threshold: high
+          target-file: ./<< parameters.serviceName >>/Dockerfile
 
   publish-image:
     parameters:

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -688,8 +688,13 @@ jobs:
 
   publish-image-kmi:
     parameters:
-      imageRepository:
+      namespace:
         type: string
+      application:
+        type: string
+      sandboxIdentifier:
+        type: string
+        default: ""
       <<: *image
     machine:
       docker_layer_caching: false
@@ -697,7 +702,7 @@ jobs:
     steps:
       - aws-ecr/ecr-login
       - aws-ecr/push-image:
-          repo: << parameters.imageRepository >>
+          repo: << parameters.namespace >>/<< parameters.application >><< parameters.sandboxIdentifier >>
           tag: '${CIRCLE_SHA1}'
 
   publish-image:

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -688,25 +688,17 @@ jobs:
 
   publish-image-kmi:
     parameters:
-      privateDockerImage: 
-        type: boolean
-        default: false
-      username:
+      path:
         type: string
-        default: $GITHUB_BOT_USERNAME
-      token:
+      repo:
         type: string
-        default: $GITHUB_BOT_PACKAGE_MANAGER_TOKEN
-      namespace:
+      dockerImageName:
         type: string
-      application:
+      snykProject:
         type: string
-      sandboxIdentifier:
+      tag:
         type: string
-        default: ""
-      serviceName:
-        type: string
-        default: << parameters.application >>-service
+        default: ${CIRCLE_SHA1}
       <<: *resourceClass
       <<: *parallelism
     parallelism: << parameters.parallelism >>
@@ -716,27 +708,19 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/working
-      - when:
-          condition:
-            equal: [ "true", << parameters.privateDockerImage >> ]
-          steps:
-            - github-repo-login:
-                username: << parameters.username >>
-                token: << parameters.token >>
       - aws-ecr/build-and-push-image:
           setup-remote-docker: true
           checkout: false
-          path: ./<< parameters.serviceName >>
-          create-repo: false
-          repo: << parameters.namespace >>/<< parameters.application >><< parameters.sandboxIdentifier >>
-          tag: '${CIRCLE_SHA1}'
+          path: << parameters.path >>
+          repo: << parameters.repo >>
+          tag: '<< parameters.tag >>'
       - snyk/scan:
-          docker-image-name: $AWS_ACCOUNT_URL/<< parameters.namespace >>/<< parameters.application >><< parameters.sandboxIdentifier >>:$CIRCLE_SHA1
+          docker-image-name: $AWS_ECR_ACCOUNT_URL/<< parameters.dockerImageName >>:<< parameters.tag >>
           fail-on-issues: true
           monitor-on-build: true
-          project: << parameters.namespace >>-<< parameters.application >>
+          project: << parameters.snykProject >>
           severity-threshold: high
-          target-file: ./<< parameters.serviceName >>/Dockerfile
+          target-file: << parameters.path >>/Dockerfile
 
   publish-image:
     parameters:

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -690,6 +690,10 @@ jobs:
     parameters:
       imageRepository:
         type: string
+      <<: *image
+    machine:
+      docker_layer_caching: false
+      image: << parameters.image >>
     steps:
       - aws-ecr/ecr-login
       - aws-ecr/push-image:

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -2,7 +2,7 @@ version: 2.1
 description: "Defines the core steps required for a smart journey deployment pipeline"
 
 orbs:
-  aws-ecr: circleci/aws-ecr@7.0.0
+  aws-ecr: circleci/aws-ecr@7.2.0
   terraform: ovotech/terraform@1.8.2
   openjdk-install: cloudesire/openjdk-install@1.2.3
   snyk: snyk/snyk@1.1.2
@@ -685,6 +685,16 @@ jobs:
           paths:
             - << parameters.lib >>/*
             - ./reports/jacoco/*
+
+  publish-image-kmi:
+    parameters:
+      imageRepository:
+        type: string
+    steps:
+      - aws-ecr/ecr-login
+      - aws-ecr/push-image:
+          repo: << parameters.imageRepository >>
+          tag: '${CIRCLE_SHA1}'
 
   publish-image:
     parameters:

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -178,6 +178,36 @@ commands:
             include ./scripts/make_gradle_executable.sh
             include ./scripts/run_integration_test.sh
 
+  publish-image-kmi:
+    parameters:
+      path:
+        type: string
+      repo:
+        type: string
+      dockerImageName:
+        type: string
+      snykProject:
+        type: string
+      tag:
+        type: string
+        default: ${CIRCLE_SHA1}
+      <<: *resourceClass
+    steps:
+      - attach_workspace:
+          at: ~/working
+      - aws-ecr/build-and-push-image:
+          setup-remote-docker: true
+          checkout: false
+          path: << parameters.path >>
+          repo: << parameters.repo >>
+          tag: '<< parameters.tag >>'
+      - snyk/scan:
+          docker-image-name: $AWS_ECR_ACCOUNT_URL/<< parameters.dockerImageName >>:<< parameters.tag >>
+          fail-on-issues: true
+          monitor-on-build: true
+          project: << parameters.snykProject >>
+          severity-threshold: high
+          target-file: << parameters.path >>/Dockerfile
 
   build_and_test:
     parameters:
@@ -685,42 +715,6 @@ jobs:
           paths:
             - << parameters.lib >>/*
             - ./reports/jacoco/*
-
-  publish-image-kmi:
-    parameters:
-      path:
-        type: string
-      repo:
-        type: string
-      dockerImageName:
-        type: string
-      snykProject:
-        type: string
-      tag:
-        type: string
-        default: ${CIRCLE_SHA1}
-      <<: *resourceClass
-      <<: *parallelism
-    parallelism: << parameters.parallelism >>
-    resource_class: << parameters.resourceClass >>
-    executor: kotlin
-    working_directory: ~/working
-    steps:
-      - attach_workspace:
-          at: ~/working
-      - aws-ecr/build-and-push-image:
-          setup-remote-docker: true
-          checkout: false
-          path: << parameters.path >>
-          repo: << parameters.repo >>
-          tag: '<< parameters.tag >>'
-      - snyk/scan:
-          docker-image-name: $AWS_ECR_ACCOUNT_URL/<< parameters.dockerImageName >>:<< parameters.tag >>
-          fail-on-issues: true
-          monitor-on-build: true
-          project: << parameters.snykProject >>
-          severity-threshold: high
-          target-file: << parameters.path >>/Dockerfile
 
   publish-image:
     parameters:

--- a/jaws-journey-deploy/orb_version.txt
+++ b/jaws-journey-deploy/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/jaws-journey-deploy@1.11.24
+ovotech/jaws-journey-deploy@1.11.25


### PR DESCRIPTION
Added command which supports build and pushing of images to KMI ECR. Also added undefined environment enum option for scenarios where builds are environment agnostic.