### PR TITLE
Fix IPA deploy script quotes

### DIFF
--- a/ipa-deploy/README.md
+++ b/ipa-deploy/README.md
@@ -15,7 +15,7 @@ parameter for the slack orb's `notify` command.
 
 ```yaml
 orbs:
-  ipa-deploy: ovotech/ipa-deploy@0.1.0
+  ipa-deploy: ovotech/ipa-deploy@1.0.1
 
 jobs:
   load-slack-templates:

--- a/ipa-deploy/orb.yml
+++ b/ipa-deploy/orb.yml
@@ -85,9 +85,10 @@ commands:
           command: |
             echo Saving template to file
             mkdir -p /tmp/ipa-deploy
-            echo "<< parameters.deploy_failed_template >>" > /tmp/ipa-deploy/failed_deploy_template.json
+            echo '<< parameters.deploy_failed_template >>' > /tmp/ipa-deploy/failed_deploy_template.json
 
       - run:
           name: Export template to environment variable
           command: |
+            echo $(cat /tmp/ipa-deploy/failed_deploy_template.json)
             echo 'export SLACK_DEPLOY_FAILED_TEMPLATE=$(cat /tmp/ipa-deploy/failed_deploy_template.json)' >> $BASH_ENV

--- a/ipa-deploy/orb_version.txt
+++ b/ipa-deploy/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/ipa-deploy@0.1.0
+ovotech/ipa-deploy@1.0.1


### PR DESCRIPTION
Wrapping parameter in double quotes was causing param string double quotes to disappear. 

Using single quotes on script instead.