### PR TITLE
Use smaller executor for helm-ci orb

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ any changes to the orb.
  - [ovotech/jaws-journey-deploy](jaws-journey-deploy) - Provides a standard deployment process for all jaws journey repositories.
  - [ovotech/pipeline-utils](pipeline-utils) - Miscellaneous bash commands to ease CircleCI pipeline development.
  - [ovotech/ipa-deploy](ipa-deploy) - IPA team deployment notification templates.
+ - [ovotech/helm](helm-ci) - CI checks for Helm charts
 
  Other orbs in the ovotech namespace:
  - [ovotech/shipit@1](https://github.com/ovotech/pe-orbs/tree/master/shipit) - Run shipit and record deployments to https://shipit.ovotech.org.uk.

--- a/helm-ci/CHANGELOG.md
+++ b/helm-ci/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to the orb will be documented in this file.
+Orbs are immutable, some orb versions with no significant changes are
+not listed
+
+## ovotech/helm-ci@1.0.1
+## Changed
+- Use small size executor
+
+## ovotech/helm-ci@1.0.0
+## Added
+- First version of orb

--- a/helm-ci/README.md
+++ b/helm-ci/README.md
@@ -8,7 +8,7 @@ Provides CI functionality for working with Helm.
 
 ```yaml
 orbs:
-  helm-ci: ovotech/helm-ci@1.0.0
+  helm-ci: ovotech/helm-ci@1.0.1
 
 workflows:
   commit:

--- a/helm-ci/README.md
+++ b/helm-ci/README.md
@@ -14,6 +14,7 @@ workflows:
   commit:
     jobs:
       - helm-ci/lint-chart:
+          name: my-linting-job
           chart_path: <path/to/helm/chart>
           values_files: <values-file.yaml>,<other-values-file.yaml>
 ```

--- a/helm-ci/README.md
+++ b/helm-ci/README.md
@@ -14,7 +14,7 @@ workflows:
   commit:
     jobs:
       - helm-ci/lint-chart:
-          name: my-linting-job
+          name: example-job-name
           chart_path: <path/to/helm/chart>
           values_files: <values-file.yaml>,<other-values-file.yaml>
 ```

--- a/helm-ci/README.md
+++ b/helm-ci/README.md
@@ -8,7 +8,7 @@ Provides CI functionality for working with Helm.
 
 ```yaml
 orbs:
-  helm-ci: ovotech/helm-ci@0.0.1
+  helm-ci: ovotech/helm-ci@1.0.0
 
 workflows:
   commit:

--- a/helm-ci/orb.yml
+++ b/helm-ci/orb.yml
@@ -3,6 +3,7 @@ description: "Defines jobs for CI with Helm"
 
 executors:
   default:
+    resource_class: small
     docker:
       - image: alpine/helm:3.7.2
 

--- a/helm-ci/orb_version.txt
+++ b/helm-ci/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/helm@1.0.0
+ovotech/helm@1.0.1

--- a/helm-ci/orb_version.txt
+++ b/helm-ci/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/helm@0.0.1
+ovotech/helm@1.0.0


### PR DESCRIPTION
This uses a small executor by default. It also updates the documentation and corrects the version to be 1.x.x as it looks like CircleCI [overwrites the version with 1.0.0](https://circleci.com/developer/orbs/orb/ovotech/helm-ci) if it's 0.x.x when published.