### PR TITLE
Allow tags to be specified when building/pushing with oot-eks

### DIFF
--- a/oot-eks/orb.yml
+++ b/oot-eks/orb.yml
@@ -33,6 +33,10 @@ commands:
         description: "Extra arguments to pass when running docker build"
         type: string
         default: ""
+      image-tags:
+        description: "Tags to push the image with"
+        type: string
+        default: ${CIRCLE_SHA1},latest
 
     steps:
       - attach_workspace:
@@ -54,7 +58,7 @@ commands:
           aws-access-key-id: << parameters.access-key-name >>
           aws-secret-access-key: << parameters.secret-access-key-name >>
           repo: << parameters.service >>
-          tag: ${CIRCLE_SHA1},latest
+          tag: << parameters.image-tags >>
           ecr-login: true
           extra-build-args: << parameters.extra-build-args >>
 
@@ -67,7 +71,7 @@ commands:
 
       - aws-ecr/push-image:
           repo: << parameters.service >>
-          tag: ${CIRCLE_SHA1},latest
+          tag: << parameters.image-tags >>
 
 executors:
   aws:

--- a/oot-eks/orb_version.txt
+++ b/oot-eks/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/oot-eks@2.1.1
+ovotech/oot-eks@2.2.1


### PR DESCRIPTION
KMI has made their ECR tags immutable. `oot-eks` tags images with both the build hash and `latest`, causing KMI ECR to complain it’s trying to update an immutable tag (`latest`).

This PR provides a parameter to specify tags and get around this problem