### PR TITLE
feat: jaws automated test env variables

### DIFF
--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -1070,6 +1070,9 @@ jobs:
       automatedTestSuite:
         type: string
         default: "automated-test"
+      deploymeny:
+        type: string
+        default: ""
     resource_class: << parameters.resourceClass >>
     executor: kotlin
     working_directory: ~/working
@@ -1080,6 +1083,7 @@ jobs:
       - run-automated-tests:
           environment: << parameters.environment >>
           automatedTestSuite: << parameters.automatedTestSuite >>
+          deployment: << parameters.deployment >>
       - save-automated-tests
       - store_test_results:
           path: ~/test-results

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -1070,7 +1070,7 @@ jobs:
       automatedTestSuite:
         type: string
         default: "automated-test"
-      deploymeny:
+      deployment:
         type: string
         default: ""
     resource_class: << parameters.resourceClass >>

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -472,13 +472,16 @@ commands:
       automatedTestSuite:
         type: string
         default: "automated-test"
+      deployment:
+        type: string
+        default: ""
     steps:
       - run:
           name: "Run automated tests"
           shell: /bin/bash -eo pipefail
           command: |
             echo 'export AUTOMATED_TEST_SUITE="<< parameters.automatedTestSuite >>"'
-            echo 'export SPH_VERSION="green"'
+            echo 'export DEPLOYMENT="<< parameters.deployment >>"'
             include ./scripts/set_profile.sh
             include ./scripts/automated_test_run.sh
 

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -478,6 +478,7 @@ commands:
           shell: /bin/bash -eo pipefail
           command: |
             echo 'export AUTOMATED_TEST_SUITE="<< parameters.automatedTestSuite >>"'
+            echo 'export SPH_VERSION="green"'
             include ./scripts/set_profile.sh
             include ./scripts/automated_test_run.sh
 

--- a/jaws-journey-deploy/orb_version.txt
+++ b/jaws-journey-deploy/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/jaws-journey-deploy@1.11.26
+ovotech/jaws-journey-deploy@1.11.27

--- a/jaws-journey-deploy/scripts/automated_test_run.sh
+++ b/jaws-journey-deploy/scripts/automated_test_run.sh
@@ -1,3 +1,4 @@
 export AWS_REGION=${AWS_DEFAULT_REGION}
 export AUTOMATED_TEST_SUITE="<< parameters.automatedTestSuite >>"
+export DEPLOYMENT="<< parameters.deployment >>"
 ./gradlew :${AUTOMATED_TEST_SUITE}:test -Pprofile=${PROFILE} --full-stacktrace -PrunEndToEndTests=true


### PR DESCRIPTION
In MARS we have the ability to run 2 parallel environments and during automated testing we need to identify which environment is being tested (in order to determine which database to use).

Added a new environment variable of 'DEPLOYMENT' to the run-automation-test job to enable this, which defaults to an empty string.