### PR TITLE
Update to using the Jukie repo for tfswitch in terraform docker container

### DIFF
--- a/terraform/executor/Dockerfile
+++ b/terraform/executor/Dockerfile
@@ -3,7 +3,7 @@
 FROM debian:buster-slim
 
 ARG TFMASK_VERSION="0.7.0"
-ARG TFSWITCH_VERSION=0.11.1071
+ARG TFSWITCH_VERSION=0.13.12345
 ARG GCLOUD_VERSION=329.0.0
 ARG AWSCLI_VERSION=1.19.16
 ARG HELM3_VERSION=3.5.3
@@ -39,7 +39,7 @@ RUN curl -fsL https://github.com/cloudposse/tfmask/releases/download/${TFMASK_VE
  && mv tfmask /usr/local/bin
 
 # tfswitch
-RUN curl -fsL https://github.com/warrensbox/terraform-switcher/releases/download/${TFSWITCH_VERSION}/terraform-switcher_${TFSWITCH_VERSION}_linux_amd64.tar.gz -o tfswitch.tar.gz \
+RUN curl -fsL https://github.com/Jukie/terraform-switcher/releases/download/${TFSWITCH_VERSION}/terraform-switcher_${TFSWITCH_VERSION}_linux_amd64.tar.gz -o tfswitch.tar.gz \
     && tar -xvf tfswitch.tar.gz tfswitch \
     && mv tfswitch /usr/local/bin \
     && rm -rf tfswitch.tar.gz


### PR DESCRIPTION
There is a current issue with the original tfswitch as hashicorp changed
their website and so the bit of tfswitch which scrapes that info is
failing. This is a temporary fix until the PR is merged on tfswitch.

github issue: https://github.com/warrensbox/terraform-switcher/pull/225
differences between versions: https://github.com/warrensbox/terraform-switcher/compare/master...Jukie:fix-release-downloads

---

Alrighty - so this may not be needed by tomorrow if the tfswitch people wake up and merge their PR - at which point we just need to update to the latest version. But opening this PR so that we can merge the change and people can run their terraform still if that is going to take a while