### PR TITLE
Add new kap-kmi-deploy orb.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,3 +40,4 @@ workflows:
             tools-install/.* run-tools-install true
             versioned-lambda/.* run-versioned-lambda true
             with-git-deploy-key/.* run-with-git-deploy-key true
+            kap-kmi-deploy/.* run-kap-kmi-deploy true

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -87,6 +87,9 @@ parameters:
   run-with-git-deploy-key:
     type: boolean
     default: false
+  run-kap-kmi-deploy:
+    type: boolean
+    default: false
 
 jobs:
   test_python:
@@ -495,5 +498,14 @@ workflows:
           path: with-git-deploy-key
       - publish_orb:
           path: with-git-deploy-key
+          requires:
+            - validate_orb
+  kap-kmi-deploy:
+    when: << pipeline.parameters.run-kap-kmi-deploy >>
+    jobs:
+      - validate_orb:
+          path: kap-kmi-deploy
+      - publish_orb:
+          path: kap-kmi-deploy
           requires:
             - validate_orb

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,3 +22,4 @@
 /ipa-deploy/                     @ovotech/ipa
 /sast/                           @ovotech/consumer-products-production-engineering
 /setup-scheduled-pipeline/       @ovotech/consumer-products-production-engineering
+/kap-kmi-deploy/                 @ovotech/agent-platform-enablement

--- a/kap-kmi-deploy/README.md
+++ b/kap-kmi-deploy/README.md
@@ -1,0 +1,83 @@
+KAP KMI [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/ovotech/kap-kmi-deploy)](https://circleci.com/orbs/registry/orb/ovotech/kap-kmi-deploy)
+=====================
+
+Provides commands for deploying images to the KAP KMI registry and pushing those images to KMI.
+
+Overview
+--------
+
+### Commands
+
+* `deploy-image` - builds and pushes a new docker image to the KAP ECR registry.
+* `update-gitops` - updates the KAP/KMI deployment manifest for the specified service to use a specified image from the KAP ECR registry.
+
+### Jobs
+
+* `deploy` - combines the two commands to build, push and deploy a new docker image of a given KAP service to KMI.
+
+### Environment variables
+
+Mandatory environment variables:
+
+* `AWS_ACCESS_KEY_ID` - for read/write access to the ECR registry.
+* `AWS_SECRET_ACCESS_KEY` - for read/write access to the ECR registry.
+* `KAP_GITOPS_SSH_KEY_FINGERPRINT` - fingerprint of the SSH key added to the Circle project settings which will allow git operations against the gitops repo.
+* `KAP_GITOPS_USERNAME`
+* `KAP_GITOPS_EMAIL`
+
+Other environment variables:
+
+* `CIRCLE_PROJECT_REPONAME` - used as the default for `service-name`, `image-name` and `kmi-k8s-namespace` 
+* `CIRCLE_SHA1` - used as a suffix to the image tag used.
+
+To get the value for the `gitops-ssh-key-fingerprint` parameter:
+
+1. In Circle CI, navigate to your Circle CI _Project Settings_.
+2. Navigate to _SSH Keys_ -> _Additional SSH Keys_.
+3. Add a new "additional" SSH key (hostname "github.com"). The key itself should be available from the maintainers of the KAP infra.
+4. Copy the resulting fingerprint.
+
+Example
+-------
+
+> The examples below assume that the git repository name matches the `service-name`, `image-name` and `kmi-k8s-namespace`
+> parameters - if it does not these parameters should be explicitly declared.
+
+Using the `deploy` job:
+
+```yaml
+orbs:
+  kmi-deploy: ovotech/kap-kmi-deploy@1.0.0
+
+workflows:
+  version: 2.1
+  service-deploy:
+    jobs:
+      - kmi-deploy/deploy:
+          name: kmi-deploy-uat
+          environment: uat
+          push-image: true
+      - kmi-deploy/deploy:
+          name: kmi-deploy-prod
+          environment: prod
+          requires:
+            - kmi-deploy-uat
+```
+
+For more granular control using the commands:
+
+```yaml
+orbs:
+  kmi-deploy: ovotech/kap-kmi-deploy@1.0.0
+
+jobs:
+  deploy:
+    executor: kmi-deploy/default
+    steps:
+      - kmi-deploy/deploy-image
+      - kmi-deploy/update-gitops:
+          environment: prod
+          gitops-ssh-key-fingerprint: "xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx"
+          gitops-username: my-bot
+          gitops-email: my-bot@myco.co.uk
+```

--- a/kap-kmi-deploy/orb.yml
+++ b/kap-kmi-deploy/orb.yml
@@ -1,0 +1,175 @@
+version: 2.1
+description: "Push to KMI via KAP-managed gitops."
+
+orbs:
+  aws-ecr: circleci/aws-ecr@8.1.2
+
+commands:
+  deploy-image:
+    description: "Builds and deploys an image to AWS ECR."
+    parameters:
+      image-name:
+        type: string
+        description: "Name of the image to deploy for the service. Defaults to the name of the github repository from where the source was pulled."
+        default: ${CIRCLE_PROJECT_REPONAME}
+      kmi-k8s-namespace:
+        type: string
+        description: "The kubernetes namespace to deploy to. Defaults to the name of the github repository from where the source was pulled."
+        default: ${CIRCLE_PROJECT_REPONAME}
+      aws-access-key-id:
+        description: "AWS access key id for IAM role. Set this to the name of the environment variable you will set to hold this value."
+        type: string
+        default: AWS_ACCESS_KEY_ID
+      aws-secret-access-key:
+        description: "AWS secret key for IAM role. Set this to the name of the environment variable you will set to hold this value."
+        type: string
+        default: AWS_SECRET_ACCESS_KEY
+      tag:
+        type: string
+        default: kmi-${CIRCLE_SHA1}
+        description: "Tag to apply to the image before pushing to the container registry to uniquely identify this version of the image."
+    steps:
+      - attach_workspace:
+          at: .
+      - aws-ecr/build-and-push-image:
+          checkout: false
+          aws-access-key-id: << parameters.aws-access-key-id >>
+          aws-secret-access-key: << parameters.aws-secret-access-key >>
+          repo: << parameters.kmi-k8s-namespace >>/<< parameters.image-name >>
+          tag: << parameters.tag >>
+
+  update-gitops:
+    parameters:
+      service-name:
+        type: string
+        description: "Name of the service being deployed. Defaults to the name of the github repository from where the source was pulled."
+        default: "${CIRCLE_PROJECT_REPONAME}"
+      environment:
+        type: string
+        description: "The deployment environment."
+      kmi-region:
+        type: string
+        description: "The KMI region to update gitops for. Defaults to updating all regions."
+        default: "*"
+      gitops-username:
+        description: "The username of the git user to push gitops changes as."
+        type: string
+        default: "${KAP_GITOPS_USERNAME}"
+      gitops-email:
+        description: "The email address of the git user to push gitops changes as."
+        type: string
+        default: "${KAP_GITOPS_EMAIL}"
+      tag:
+        type: string
+        description: "Tag used to uniquely identify the version of the service image to be updated to."
+        default: "kmi-${CIRCLE_SHA1}"
+      tag-line-match:
+        type: string
+        description: "Search string to use to find the beginning of the appropriate line in the gitops manifest to interpolate the image urn."
+        default: '      tag'
+
+    steps:
+      - attach_workspace:
+          at: .
+      - add_ssh_keys:
+          fingerprints:
+            - "ae:42:d4:4b:23:f1:01:36:32:06:3e:c2:64:89:03:9a"
+      - run:
+          name: Add host keys
+          command: |
+            ssh-keyscan github.com > ~/.ssh/known_hosts
+      - run:
+          name: Sync repo
+          command: |
+            git clone git@github.com:ovotech/kap-kmi-gitops.git /tmp/kmi/gitops
+      - run:
+          name: Update Values
+          command: |
+            cd /tmp/kmi/gitops/services/<< parameters.service-name >>
+            sed -i "s/<< parameters.tag-line-match >>\:.*$/<< parameters.tag-line-match >>\: << parameters.tag >>/" values-kmi-<< parameters.environment >>-<< parameters.kmi-region >>.yaml
+      - run:
+          name: Git push kmi changes
+          command: |
+            cd /tmp/kmi/gitops
+            git config user.email "<< parameters.gitops-email >>"
+            git config user.name "<< parameters.gitops-username >>"
+            git add --all
+            if [ -z "$(git status --porcelain)" ]; then
+              echo "No changes detected."
+            else
+              git commit -m "Bumped << parameters.service-name >> in << parameters.environment >> to tag << parameters.tag >>"
+              git push origin main
+            fi
+
+jobs:
+  deploy:
+    executor: aws
+    description: "Builds, pushes a resulting image and then triggers a redeployment of that image via gitops."
+    parameters:
+      environment:
+        type: string
+        description: "The deployment environment."
+      image-name:
+        type: string
+        description: "Name of the image to deploy for the service. Defaults to the name of the github repository from where the source was pulled."
+        default: "${CIRCLE_PROJECT_REPONAME}"
+      kmi-k8s-namespace:
+        type: string
+        description: "The kubernetes namespace to deploy to. Defaults to the name of the github repository from where the source was pulled."
+        default: "${CIRCLE_PROJECT_REPONAME}"
+      service-name:
+        type: string
+        description: "Name of the service being deployed. Defaults to the name of the github repository from where the source was pulled."
+        default: "${CIRCLE_PROJECT_REPONAME}"
+      aws-access-key-id:
+        description: "AWS access key id for IAM role. Set this to the name of the environment variable you will set to hold this value."
+        type: string
+        default: AWS_ACCESS_KEY_ID
+      aws-secret-access-key:
+        description: "AWS secret key for IAM role. Set this to the name of the environment variable you will set to hold this value."
+        type: string
+        default: AWS_SECRET_ACCESS_KEY
+      tag:
+        type: string
+        default: "kmi-${CIRCLE_SHA1}"
+        description: "Tag to apply to the image before pushing to the container registry to uniquely identify this version of the image."
+      gitops-username:
+        description: "The username of the git user to push gitops changes as."
+        type: string
+        default: "${KAP_GITOPS_USERNAME}"
+      gitops-email:
+        description: "The email address of the git user to push gitops changes as."
+        type: string
+        default: "${KAP_GITOPS_EMAIL}"
+      tag-line-match:
+        type: string
+        description: "Search string to use to find the beginning of the appropriate line in the gitops manifest to interpolate the image urn."
+        default: '      tag'
+      push-image:
+        type: boolean
+        description: "Whether a new image should be built and pushed. If false, it is assumed that the image has already been pushed."
+        default: false
+
+    steps:
+      - when:
+          condition: << parameters.push-image >>
+          steps:
+            - deploy-image:
+                image-name: << parameters.image-name >>
+                kmi-k8s-namespace: << parameters.kmi-k8s-namespace >>
+                aws-access-key-id: << parameters.aws-access-key-id >>
+                aws-secret-access-key: << parameters.aws-secret-access-key >>
+                tag: << parameters.tag >>
+
+      - update-gitops:
+          service-name: << parameters.service-name >>
+          environment: << parameters.environment >>
+          gitops-username: << parameters.gitops-username >>
+          gitops-email: << parameters.gitops-email >>
+          tag: << parameters.tag >>
+          tag-line-match: << parameters.tag-line-match >>
+
+executors:
+  aws:
+    machine:
+      image: ubuntu-2004:202201-02

--- a/kap-kmi-deploy/orb_version.txt
+++ b/kap-kmi-deploy/orb_version.txt
@@ -1,0 +1,1 @@
+ovotech/kap-kmi-deploy@1.0.0


### PR DESCRIPTION
Creates a new `kap-kmi-deploy` orb for use by the KAP squad in deploying services to KMI.

See the [README](https://github.com/ovotech/circleci-orbs/tree/kap-kmi-deploy/kap-kmi-deploy) for details.