### PR TITLE
Force a snyk monitor whenever building Clojure projects

### DIFF
--- a/clojure/orb.yml
+++ b/clojure/orb.yml
@@ -78,13 +78,14 @@ commands:
 
       - run:
           name: Generate pom.xml for Snyk
-          command: |
-            lein pom
-            cat pom.xml
+          command: lein pom
+
+      - snyk/scan:
+          command: "monitor"
 
       - snyk/scan:
           fail-on-issues: true
-          monitor-on-build: true
+          monitor-on-build: false
           severity-threshold: high
 
       - save_cache:

--- a/clojure/orb_version.txt
+++ b/clojure/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/clojure@2.0.5
+ovotech/clojure@2.0.6


### PR DESCRIPTION
This ensures that any violations that are picked up by the scanning step are available to suppress in the dashboard - currently the `monitor-on-build` option only kicks in if the scan itself passes.