### PR TITLE
Avoid hitting snyk monitor twice in the Clojure orb

### DIFF
--- a/clojure/orb.yml
+++ b/clojure/orb.yml
@@ -80,8 +80,11 @@ commands:
           name: Generate pom.xml for Snyk
           command: lein pom
 
+      # Force an explicit monitor regardless of the failure/success of a scan
       - snyk/scan:
-          command: "monitor"
+          command: "version"
+          monitor-on-build: true
+          severity-threshold: high
 
       - snyk/scan:
           fail-on-issues: true

--- a/clojure/orb_version.txt
+++ b/clojure/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/clojure@2.0.6
+ovotech/clojure@2.0.7


### PR DESCRIPTION
The `snyk/scan` implicitly will run a `monitor` if the main command succeeds. In our case, the command _is_ `monitor`, so it runs twice.

We could just disable the `monitor-on-build` but instead let's use an innocuous command `version` and let the snyk orb work out how to run a monitor.