### PR TITLE
BREAKING CHANGE: allowing usage of oidc instead of aws keys if specified

### DIFF
--- a/jaws-journey-deploy/changelog.md
+++ b/jaws-journey-deploy/changelog.md
@@ -1,0 +1,18 @@
+# 2.0.0
+
+* aws-ecr orb changed from version `7.2.0` to `8.1.3`
+* ovotech/aws-configure-credentials-oidc@1.0.1 added
+* for build-pushes and terraform jobs, oidc is used instead of aws keys/secrets if the oidc parameter is set to true when using this orb
+
+### Breaking change 
+* `docker.pkg.github.com` must be changed to `ghcr.io` in dockerfiles that use images from our github container repository
+
+### New environment variables used 
+* CIRCLE_IAM_ROLE_ARN (optional)
+* AWS_ACCOUNT_ID
+
+### Deprecated environment variables 
+* ACCOUNT_URL
+
+### New parameters 
+* oidc - boolean (optional, false by default)

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -240,7 +240,7 @@ commands:
       token:
         type: string
         default: $GITHUB_BOT_PACKAGE_MANAGER_TOKEN
-      use_oidc:
+      oidc:
         type: boolean
         default: false         
       <<: *resourceClass
@@ -290,9 +290,9 @@ commands:
             - aws-ecr/build-and-push-image:
                 setup-remote-docker: true
                 checkout: false
-                assume-web-identity: << parameters.use_oidc >>                   
-                role-arn: <<#parameters.use_oidc>>$CIRCLE_IAM_ROLE_ARN<</parameters.use_oidc>>
-                role-session-name: <<#parameters.use_oidc>>CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}<</parameters.use_oidc>> 
+                assume-web-identity: << parameters.oidc >>                   
+                role-arn: <<#parameters.oidc>>$CIRCLE_IAM_ROLE_ARN<</parameters.oidc>>
+                role-session-name: <<#parameters.oidc>>CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}<</parameters.oidc>> 
                 registry-id: AWS_ACCOUNT_ID
                 dockerfile: Dockerfile
                 path: ./<< parameters.serviceName >>
@@ -580,7 +580,7 @@ commands:
   tf:
     parameters:
       <<: *tf-common-parameters
-      using_oidc:
+      oidc:
         type: boolean
         default: false
       command:
@@ -598,7 +598,7 @@ commands:
           steps:
             - checkout
       - when:
-          condition: << parameters.using_oidc >>
+          condition: << parameters.oidc >>
           steps:            
             - aws-configure-credentials-oidc/aws-configure-credentials:
                 role-arn: $CIRCLE_IAM_ROLE_ARN              
@@ -755,7 +755,7 @@ jobs:
       token:
         type: string
         default: $GITHUB_BOT_PACKAGE_MANAGER_TOKEN
-      use_oidc:
+      oidc:
         type: boolean
         default: false             
       <<: *resourceClass
@@ -775,9 +775,9 @@ jobs:
       - aws-ecr/build-and-push-image:
           setup-remote-docker: true
           checkout: false
-          assume-web-identity: << parameters.use_oidc >>                   
-          role-arn: <<#parameters.use_oidc>>$CIRCLE_IAM_ROLE_ARN<</parameters.use_oidc>>
-          role-session-name: <<#parameters.use_oidc>>CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}<</parameters.use_oidc>>  
+          assume-web-identity: << parameters.oidc >>                   
+          role-arn: <<#parameters.oidc>>$CIRCLE_IAM_ROLE_ARN<</arameters.oidc>>
+          role-session-name: <<#parameters.oidc>>CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}<</parameters.oidc>>  
           registry-id: AWS_ACCOUNT_ID
           dockerfile: Dockerfile
           path: ./<< parameters.serviceName >>
@@ -825,7 +825,7 @@ jobs:
       token:
         type: string
         default: $GITHUB_BOT_PACKAGE_MANAGER_TOKEN
-      use_oidc:
+      oidc:
         type: boolean
         default: false              
       <<: *resourceClass
@@ -879,9 +879,9 @@ jobs:
             - aws-ecr/build-and-push-image:
                 setup-remote-docker: true
                 checkout: false
-                assume-web-identity: << parameters.use_oidc >>                   
-                role-arn: <<#parameters.use_oidc>>$CIRCLE_IAM_ROLE_ARN<</parameters.use_oidc>>
-                role-session-name: <<#parameters.use_oidc>>CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}<</parameters.use_oidc>>  
+                assume-web-identity: << parameters.oidc >>                   
+                role-arn: <<#parameters.oidc>>$CIRCLE_IAM_ROLE_ARN<</parameters.oidc>>
+                role-session-name: <<#parameters.oidc>>CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}<</parameters.oidc>>  
                 registry-id: AWS_ACCOUNT_ID
                 dockerfile: Dockerfile
                 path: ./<< parameters.serviceName >>

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -569,9 +569,7 @@ commands:
       username:
         type: string
       token:
-        type: string
-      url:
-        type: string        
+        type: string       
     steps:
       - run:
           shell: /bin/bash -eo pipefail

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -242,10 +242,7 @@ commands:
         default: $GITHUB_BOT_PACKAGE_MANAGER_TOKEN
       use_oidc:
         type: boolean
-        default: false
-      github_repo_url:
-        type: string
-        default: 'docker.pkg.github.com'          
+        default: false         
       <<: *resourceClass
       <<: *parallelism
     steps:
@@ -290,7 +287,6 @@ commands:
             - github-repo-login:
                 username: << parameters.username >>
                 token: << parameters.token >>
-                url: << parameters.github_repo_url >> 
             - aws-ecr/build-and-push-image:
                 setup-remote-docker: true
                 checkout: false
@@ -757,10 +753,7 @@ jobs:
         default: $GITHUB_BOT_PACKAGE_MANAGER_TOKEN
       use_oidc:
         type: boolean
-        default: false
-      github_repo_url:
-        type: string
-        default: 'docker.pkg.github.com'                
+        default: false             
       <<: *resourceClass
       <<: *parallelism
     parallelism: << parameters.parallelism >>
@@ -774,8 +767,7 @@ jobs:
           key: gradle-{{ checksum "build.gradle" }}-{{ checksum "<< parameters.serviceName >>/build.gradle" }}
       - github-repo-login:
           username: << parameters.username >>
-          token: << parameters.token >>
-          url: << parameters.github_repo_url >>          
+          token: << parameters.token >>        
       - aws-ecr/build-and-push-image:
           setup-remote-docker: true
           checkout: false
@@ -831,10 +823,7 @@ jobs:
         default: $GITHUB_BOT_PACKAGE_MANAGER_TOKEN
       use_oidc:
         type: boolean
-        default: false
-      github_repo_url:
-        type: string
-        default: 'docker.pkg.github.com'                
+        default: false              
       <<: *resourceClass
       <<: *parallelism
     parallelism: << parameters.parallelism >>
@@ -882,8 +871,7 @@ jobs:
           steps:
             - github-repo-login:
                 username: << parameters.username >>
-                token: << parameters.token >>
-                url: << parameters.github_repo_url >>                
+                token: << parameters.token >>              
             - aws-ecr/build-and-push-image:
                 setup-remote-docker: true
                 checkout: false

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -292,7 +292,7 @@ commands:
                 checkout: false
                 assume-web-identity: << parameters.use_oidc >>                   
                 role-arn: <<#parameters.use_oidc>>$CIRCLE_IAM_ROLE_ARN<</parameters.use_oidc>>
-                role-session-name: <<#parameters.use_oidc>>'CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}'<</parameters.use_oidc>> 
+                role-session-name: <<#parameters.use_oidc>>CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}<</parameters.use_oidc>> 
                 registry-id: AWS_ACCOUNT_ID
                 dockerfile: Dockerfile
                 path: ./<< parameters.serviceName >>
@@ -771,7 +771,7 @@ jobs:
           checkout: false
           assume-web-identity: << parameters.use_oidc >>                   
           role-arn: <<#parameters.use_oidc>>$CIRCLE_IAM_ROLE_ARN<</parameters.use_oidc>>
-          role-session-name: <<#parameters.use_oidc>>'CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}'<</parameters.use_oidc>>  
+          role-session-name: <<#parameters.use_oidc>>CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}<</parameters.use_oidc>>  
           registry-id: AWS_ACCOUNT_ID
           dockerfile: Dockerfile
           path: ./<< parameters.serviceName >>
@@ -875,7 +875,7 @@ jobs:
                 checkout: false
                 assume-web-identity: << parameters.use_oidc >>                   
                 role-arn: <<#parameters.use_oidc>>$CIRCLE_IAM_ROLE_ARN<</parameters.use_oidc>>
-                role-session-name: <<#parameters.use_oidc>>'CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}'<</parameters.use_oidc>>  
+                role-session-name: <<#parameters.use_oidc>>CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}<</parameters.use_oidc>>  
                 registry-id: AWS_ACCOUNT_ID
                 dockerfile: Dockerfile
                 path: ./<< parameters.serviceName >>

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -293,7 +293,7 @@ commands:
                 dockerfile: Dockerfile
                 path: ./<< parameters.serviceName >>
                 create-repo: false
-                region: AWS_DEFAULT_REGION
+                region: $AWS_DEFAULT_REGION
                 repo: << parameters.serviceName >>
                 tag: "latest,$CIRCLE_SHA1"
             - snyk/scan:
@@ -767,7 +767,7 @@ jobs:
           dockerfile: Dockerfile
           path: ./<< parameters.serviceName >>
           create-repo: false
-          region: AWS_DEFAULT_REGION
+          region: $AWS_DEFAULT_REGION
           repo: << parameters.serviceName >>
           tag: "latest,$CIRCLE_SHA1"
       - snyk/scan:
@@ -868,7 +868,7 @@ jobs:
                 dockerfile: Dockerfile
                 path: ./<< parameters.serviceName >>
                 create-repo: false
-                region: AWS_DEFAULT_REGION
+                region: $AWS_DEFAULT_REGION
                 repo: << parameters.serviceName >>
                 tag: "latest,$CIRCLE_SHA1"
             - snyk/scan:

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -580,6 +580,9 @@ commands:
   tf:
     parameters:
       <<: *tf-common-parameters
+      using_oidc:
+        type: boolean
+        default: false
       command:
         type: "enum"
         enum: [ "plan", "apply" ]
@@ -594,8 +597,11 @@ commands:
           condition: << parameters.attach_workspace >>
           steps:
             - checkout
-      - aws-configure-credentials-oidc/aws-configure-credentials:
-          role-arn: $CIRCLE_IAM_ROLE_ARN              
+      - when:
+          condition: << parameters.using_oidc >>
+          steps:            
+            - aws-configure-credentials-oidc/aws-configure-credentials:
+                role-arn: $CIRCLE_IAM_ROLE_ARN              
       - calculate-build-version
       - terraform/fmt-check:
           path: terraform/<< parameters.path >>

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -69,6 +69,9 @@ aliases:
       destroy_first:
         type: boolean
         default: false
+      oidc:
+        type: boolean
+        default: false  
       vars_dir:
         type: string
         description: "Path to directory containing Terraform variables file.  Do not supply the ending slash /"
@@ -582,10 +585,7 @@ commands:
       <<: *tf-common-parameters
       command:
         type: "enum"
-        enum: [ "plan", "apply" ]
-      oidc:
-        type: boolean
-        default: false          
+        enum: [ "plan", "apply" ]         
     description: tf << parameters.command >> << parameters.environment >>
     steps:
       - when:
@@ -993,11 +993,7 @@ jobs:
     working_directory: ~/working
     <<: *tf-common
     environment:
-      <<: *tf-mask
-    parameters:
-      oidc:
-        type: boolean
-        default: false      
+      <<: *tf-mask     
     steps:
       - tf:
           <<: *tf-command-parameters
@@ -1009,11 +1005,7 @@ jobs:
     working_directory: ~/working
     <<: *tf-common
     environment:
-      <<: *tf-mask
-    parameters:
-      oidc:
-        type: boolean
-        default: false       
+      <<: *tf-mask       
     steps:
       - tf:
           <<: *tf-command-parameters
@@ -1025,11 +1017,7 @@ jobs:
     working_directory: ~/working
     <<: *tf-common
     environment:
-      <<: *tf-mask
-    parameters:
-      oidc:
-        type: boolean
-        default: false       
+      <<: *tf-mask      
     steps:
       - tf-install-adoptopenjdk
       - tf:
@@ -1042,11 +1030,7 @@ jobs:
     working_directory: ~/working
     <<: *tf-common
     environment:
-      <<: *tf-mask
-    parameters:
-      oidc:
-        type: boolean
-        default: false       
+      <<: *tf-mask      
     steps:
       - tf-install-adoptopenjdk
       - tf:

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -776,7 +776,7 @@ jobs:
           setup-remote-docker: true
           checkout: false
           assume-web-identity: << parameters.oidc >>                   
-          role-arn: <<#parameters.oidc>>$CIRCLE_IAM_ROLE_ARN<</arameters.oidc>>
+          role-arn: <<#parameters.oidc>>$CIRCLE_IAM_ROLE_ARN<</parameters.oidc>>
           role-session-name: <<#parameters.oidc>>CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}<</parameters.oidc>>  
           registry-id: AWS_ACCOUNT_ID
           dockerfile: Dockerfile

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -2,7 +2,7 @@ version: 2.1
 description: "Defines the core steps required for a smart journey deployment pipeline"
 
 orbs:
-  aws-ecr: circleci/aws-ecr@7.2.0
+  aws-ecr: circleci/aws-ecr@8.1.3
   terraform: ovotech/terraform@1.11.13
   openjdk-install: cloudesire/openjdk-install@1.2.3
   snyk: snyk/snyk@1.1.2
@@ -286,9 +286,10 @@ commands:
             - aws-ecr/build-and-push-image:
                 setup-remote-docker: true
                 checkout: false
-                account-url: AWS_ACCOUNT_URL
-                aws-access-key-id: AWS_ACCESS_KEY_ID
-                aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+                assume-web-identity: true                   
+                role-arn: CIRCLE_IAM_ROLE_ARN
+                role-session-name: 'CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}' 
+                registry-id: AWS_ACCOUNT_ID
                 dockerfile: Dockerfile
                 path: ./<< parameters.serviceName >>
                 create-repo: false
@@ -759,9 +760,10 @@ jobs:
       - aws-ecr/build-and-push-image:
           setup-remote-docker: true
           checkout: false
-          account-url: AWS_ACCOUNT_URL
-          aws-access-key-id: AWS_ACCESS_KEY_ID
-          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+          assume-web-identity: true                   
+          role-arn: CIRCLE_IAM_ROLE_ARN
+          role-session-name: 'CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}' 
+          registry-id: AWS_ACCOUNT_ID
           dockerfile: Dockerfile
           path: ./<< parameters.serviceName >>
           create-repo: false
@@ -859,9 +861,10 @@ jobs:
             - aws-ecr/build-and-push-image:
                 setup-remote-docker: true
                 checkout: false
-                account-url: AWS_ACCOUNT_URL
-                aws-access-key-id: AWS_ACCESS_KEY_ID
-                aws-secret-access-key: AWS_SECRET_ACCESS_KEY
+                assume-web-identity: true                   
+                role-arn: CIRCLE_IAM_ROLE_ARN
+                role-session-name: 'CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}' 
+                registry-id: AWS_ACCOUNT_ID
                 dockerfile: Dockerfile
                 path: ./<< parameters.serviceName >>
                 create-repo: false

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -580,12 +580,12 @@ commands:
   tf:
     parameters:
       <<: *tf-common-parameters
-      oidc:
-        type: boolean
-        default: false
       command:
         type: "enum"
         enum: [ "plan", "apply" ]
+      oidc:
+        type: boolean
+        default: false          
     description: tf << parameters.command >> << parameters.environment >>
     steps:
       - when:
@@ -994,9 +994,14 @@ jobs:
     <<: *tf-common
     environment:
       <<: *tf-mask
+    parameters:
+      oidc:
+        type: boolean
+        default: false      
     steps:
       - tf:
           <<: *tf-command-parameters
+          oidc: << parameters.oidc >>
           command: plan
 
   tf-apply:
@@ -1005,9 +1010,14 @@ jobs:
     <<: *tf-common
     environment:
       <<: *tf-mask
+    parameters:
+      oidc:
+        type: boolean
+        default: false       
     steps:
       - tf:
           <<: *tf-command-parameters
+          oidc: << parameters.oidc >>
           command: apply
 
   tf-plan-java:
@@ -1016,10 +1026,15 @@ jobs:
     <<: *tf-common
     environment:
       <<: *tf-mask
+    parameters:
+      oidc:
+        type: boolean
+        default: false       
     steps:
       - tf-install-adoptopenjdk
       - tf:
           <<: *tf-command-parameters
+          oidc: << parameters.oidc >>          
           command: plan
 
   tf-apply-java:
@@ -1028,10 +1043,15 @@ jobs:
     <<: *tf-common
     environment:
       <<: *tf-mask
+    parameters:
+      oidc:
+        type: boolean
+        default: false       
     steps:
       - tf-install-adoptopenjdk
       - tf:
           <<: *tf-command-parameters
+          oidc: << parameters.oidc >>
           command: apply
 
   gitops-deploy:

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -2,6 +2,7 @@ version: 2.1
 description: "Defines the core steps required for a smart journey deployment pipeline"
 
 orbs:
+  aws-configure-credentials-oidc: ovotech/aws-configure-credentials-oidc@1.0.1  
   aws-ecr: circleci/aws-ecr@8.1.3
   terraform: ovotech/terraform@1.11.13
   openjdk-install: cloudesire/openjdk-install@1.2.3
@@ -590,6 +591,8 @@ commands:
           condition: << parameters.attach_workspace >>
           steps:
             - checkout
+      - aws-configure-credentials-oidc/aws-configure-credentials:
+          role-arn: $CIRCLE_IAM_ROLE_ARN              
       - calculate-build-version
       - terraform/fmt-check:
           path: terraform/<< parameters.path >>

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -240,6 +240,12 @@ commands:
       token:
         type: string
         default: $GITHUB_BOT_PACKAGE_MANAGER_TOKEN
+      use_oidc:
+        type: boolean
+        default: false
+      github_repo_url:
+        type: string
+        default: 'docker.pkg.github.com'          
       <<: *resourceClass
       <<: *parallelism
     steps:
@@ -281,15 +287,18 @@ commands:
       - when:
           condition: << parameters.publish >>
           steps:
+            - when: 
+                condition: 
             - github-repo-login:
                 username: << parameters.username >>
                 token: << parameters.token >>
+                url: << parameters.github_repo_url >> 
             - aws-ecr/build-and-push-image:
                 setup-remote-docker: true
                 checkout: false
-                assume-web-identity: true                   
-                role-arn: $CIRCLE_IAM_ROLE_ARN
-                role-session-name: 'CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}' 
+                assume-web-identity: << parameters.use_oidc >>                   
+                role-arn: <<#parameters.use_oidc>>$CIRCLE_IAM_ROLE_ARN<</parameters.use_oidc>>
+                role-session-name: <<#parameters.use_oidc>>'CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}'<</parameters.use_oidc>> 
                 registry-id: AWS_ACCOUNT_ID
                 dockerfile: Dockerfile
                 path: ./<< parameters.serviceName >>
@@ -567,6 +576,8 @@ commands:
         type: string
       token:
         type: string
+      url:
+        type: string        
     steps:
       - run:
           shell: /bin/bash -eo pipefail
@@ -746,6 +757,12 @@ jobs:
       token:
         type: string
         default: $GITHUB_BOT_PACKAGE_MANAGER_TOKEN
+      use_oidc:
+        type: boolean
+        default: false
+      github_repo_url:
+        type: string
+        default: 'docker.pkg.github.com'                
       <<: *resourceClass
       <<: *parallelism
     parallelism: << parameters.parallelism >>
@@ -760,12 +777,13 @@ jobs:
       - github-repo-login:
           username: << parameters.username >>
           token: << parameters.token >>
+          url: << parameters.github_repo_url >>          
       - aws-ecr/build-and-push-image:
           setup-remote-docker: true
           checkout: false
-          assume-web-identity: true                   
-          role-arn: $CIRCLE_IAM_ROLE_ARN
-          role-session-name: 'CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}' 
+          assume-web-identity: << parameters.use_oidc >>                   
+          role-arn: <<#parameters.use_oidc>>$CIRCLE_IAM_ROLE_ARN<</parameters.use_oidc>>
+          role-session-name: <<#parameters.use_oidc>>'CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}'<</parameters.use_oidc>>  
           registry-id: AWS_ACCOUNT_ID
           dockerfile: Dockerfile
           path: ./<< parameters.serviceName >>
@@ -813,6 +831,12 @@ jobs:
       token:
         type: string
         default: $GITHUB_BOT_PACKAGE_MANAGER_TOKEN
+      use_oidc:
+        type: boolean
+        default: false
+      github_repo_url:
+        type: string
+        default: 'docker.pkg.github.com'                
       <<: *resourceClass
       <<: *parallelism
     parallelism: << parameters.parallelism >>
@@ -861,12 +885,13 @@ jobs:
             - github-repo-login:
                 username: << parameters.username >>
                 token: << parameters.token >>
+                url: << parameters.github_repo_url >>                
             - aws-ecr/build-and-push-image:
                 setup-remote-docker: true
                 checkout: false
-                assume-web-identity: true                   
-                role-arn: $CIRCLE_IAM_ROLE_ARN
-                role-session-name: 'CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}' 
+                assume-web-identity: << parameters.use_oidc >>                   
+                role-arn: <<#parameters.use_oidc>>$CIRCLE_IAM_ROLE_ARN<</parameters.use_oidc>>
+                role-session-name: <<#parameters.use_oidc>>'CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}'<</parameters.use_oidc>>  
                 registry-id: AWS_ACCOUNT_ID
                 dockerfile: Dockerfile
                 path: ./<< parameters.serviceName >>

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -287,8 +287,6 @@ commands:
       - when:
           condition: << parameters.publish >>
           steps:
-            - when: 
-                condition: 
             - github-repo-login:
                 username: << parameters.username >>
                 token: << parameters.token >>

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -287,13 +287,13 @@ commands:
                 setup-remote-docker: true
                 checkout: false
                 assume-web-identity: true                   
-                role-arn: CIRCLE_IAM_ROLE_ARN
+                role-arn: $CIRCLE_IAM_ROLE_ARN
                 role-session-name: 'CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}' 
-                registry-id: AWS_ACCOUNT_ID
+                registry-id: $AWS_ACCOUNT_ID
                 dockerfile: Dockerfile
                 path: ./<< parameters.serviceName >>
                 create-repo: false
-                region: AWS_DEFAULT_REGION
+                region: $AWS_DEFAULT_REGION
                 repo: << parameters.serviceName >>
                 tag: "latest,$CIRCLE_SHA1"
             - snyk/scan:
@@ -761,13 +761,13 @@ jobs:
           setup-remote-docker: true
           checkout: false
           assume-web-identity: true                   
-          role-arn: CIRCLE_IAM_ROLE_ARN
+          role-arn: $CIRCLE_IAM_ROLE_ARN
           role-session-name: 'CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}' 
-          registry-id: AWS_ACCOUNT_ID
+          registry-id: $AWS_ACCOUNT_ID
           dockerfile: Dockerfile
           path: ./<< parameters.serviceName >>
           create-repo: false
-          region: AWS_DEFAULT_REGION
+          region: $AWS_DEFAULT_REGION
           repo: << parameters.serviceName >>
           tag: "latest,$CIRCLE_SHA1"
       - snyk/scan:
@@ -862,13 +862,13 @@ jobs:
                 setup-remote-docker: true
                 checkout: false
                 assume-web-identity: true                   
-                role-arn: CIRCLE_IAM_ROLE_ARN
+                role-arn: $CIRCLE_IAM_ROLE_ARN
                 role-session-name: 'CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}' 
-                registry-id: AWS_ACCOUNT_ID
+                registry-id: $AWS_ACCOUNT_ID
                 dockerfile: Dockerfile
                 path: ./<< parameters.serviceName >>
                 create-repo: false
-                region: AWS_DEFAULT_REGION
+                region: $AWS_DEFAULT_REGION
                 repo: << parameters.serviceName >>
                 tag: "latest,$CIRCLE_SHA1"
             - snyk/scan:

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -289,11 +289,11 @@ commands:
                 assume-web-identity: true                   
                 role-arn: $CIRCLE_IAM_ROLE_ARN
                 role-session-name: 'CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}' 
-                registry-id: $AWS_ACCOUNT_ID
+                registry-id: AWS_ACCOUNT_ID
                 dockerfile: Dockerfile
                 path: ./<< parameters.serviceName >>
                 create-repo: false
-                region: $AWS_DEFAULT_REGION
+                region: AWS_DEFAULT_REGION
                 repo: << parameters.serviceName >>
                 tag: "latest,$CIRCLE_SHA1"
             - snyk/scan:
@@ -763,11 +763,11 @@ jobs:
           assume-web-identity: true                   
           role-arn: $CIRCLE_IAM_ROLE_ARN
           role-session-name: 'CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}' 
-          registry-id: $AWS_ACCOUNT_ID
+          registry-id: AWS_ACCOUNT_ID
           dockerfile: Dockerfile
           path: ./<< parameters.serviceName >>
           create-repo: false
-          region: $AWS_DEFAULT_REGION
+          region: AWS_DEFAULT_REGION
           repo: << parameters.serviceName >>
           tag: "latest,$CIRCLE_SHA1"
       - snyk/scan:
@@ -864,11 +864,11 @@ jobs:
                 assume-web-identity: true                   
                 role-arn: $CIRCLE_IAM_ROLE_ARN
                 role-session-name: 'CircleCI-${CIRCLE_PROJECT_REPONAME}-${CIRCLE_BUILD_NUM}' 
-                registry-id: $AWS_ACCOUNT_ID
+                registry-id: AWS_ACCOUNT_ID
                 dockerfile: Dockerfile
                 path: ./<< parameters.serviceName >>
                 create-repo: false
-                region: $AWS_DEFAULT_REGION
+                region: AWS_DEFAULT_REGION
                 repo: << parameters.serviceName >>
                 tag: "latest,$CIRCLE_SHA1"
             - snyk/scan:

--- a/jaws-journey-deploy/orb_version.txt
+++ b/jaws-journey-deploy/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/jaws-journey-deploy@1.13.2
+ovotech/jaws-journey-deploy@2.0.0

--- a/jaws-journey-deploy/scripts/github_docker_login.sh
+++ b/jaws-journey-deploy/scripts/github_docker_login.sh
@@ -1,6 +1,5 @@
 
 USERNAME="<< parameters.username >>"
 TOKEN="<< parameters.token >>"
-URL="<< parameters.url >>"
 
-docker login https://$URL -u $USERNAME -p $TOKEN
+docker login https://ghcr.io -u $USERNAME -p $TOKEN

--- a/jaws-journey-deploy/scripts/github_docker_login.sh
+++ b/jaws-journey-deploy/scripts/github_docker_login.sh
@@ -1,5 +1,6 @@
 
 USERNAME="<< parameters.username >>"
 TOKEN="<< parameters.token >>"
+URL="<< parameters.url >>"
 
-docker login https://ghcr.io -u $USERNAME -p $TOKEN
+docker login https://$URL -u $USERNAME -p $TOKEN

--- a/jaws-journey-deploy/scripts/github_docker_login.sh
+++ b/jaws-journey-deploy/scripts/github_docker_login.sh
@@ -2,4 +2,4 @@
 USERNAME="<< parameters.username >>"
 TOKEN="<< parameters.token >>"
 
-docker login https://docker.pkg.github.com -u $USERNAME -p $TOKEN
+docker login https://ghcr.io -u $USERNAME -p $TOKEN


### PR DESCRIPTION
upversioning to circleci/aws-ecr@8.1.3 and allowing usage of oidc instead of aws keys/secrets if specified
This version uses oidc for the relevant jobs if the oidc parameter is set to true. Otherwise it will look for AWS keys as before by default
The newer aws-ecr version uses a newer docker version + buildx which doesn't seem to work with the deprecated github container repo url (docker.pkg.github.com). It fails to pull images with 401's despite a login using the same url. 
So i've changed the login to use the new url (ghcr.io). This is the breaking part of the change and requires any github container repo urls in dockerfiles to be amended to ghcr.io

### **NEW CONTEXT VARIABLES USED**
CIRCLE_IAM_ROLE_ARN (optional)
AWS_ACCOUNT_ID (already in jaws contexts)

### **DEPRECATED CONTEXT VARIABLES**
ACCOUNT_URL