### PR TITLE
Cgi 20520 multi arch image build utility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,3 +42,4 @@ workflows:
             versioned-lambda/.* run-versioned-lambda true
             with-git-deploy-key/.* run-with-git-deploy-key true
             kap-kmi-deploy/.* run-kap-kmi-deploy true
+            build-utilities/.* run-build-utilities true

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -93,7 +93,10 @@ parameters:
   run-kap-kmi-deploy:
     type: boolean
     default: false
-
+  run-build-utilities:
+    type: boolean
+    default: false
+    
 jobs:
   test_python:
     description: Tests python code within an orb

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -521,3 +521,12 @@ workflows:
           path: kap-kmi-deploy
           requires:
             - validate_orb
+  build-utilities:
+    when: << pipeline.parameters.run-build-utilities >>
+    jobs:
+      - validate_orb:
+          path: build-utilities
+      - publish_orb:
+          path: build-utilities
+          requires:
+            - validate_orb

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,3 +23,4 @@
 /sast/                           @ovotech/consumer-products-production-engineering
 /setup-scheduled-pipeline/       @ovotech/consumer-products-production-engineering
 /kap-kmi-deploy/                 @ovotech/agent-platform-enablement
+/build-utilities                 @ovotech/ohs-domainleads

--- a/build-utilities/CHANGELOG.md
+++ b/build-utilities/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+All notable changes to the orb will be documented in this file.
+
+## @ovotech/build-utilities@0.1.1
+## Changed
+- First version of orb

--- a/build-utilities/README.md
+++ b/build-utilities/README.md
@@ -1,5 +1,72 @@
-#Build utilities
+# Build scripts
 
-This orb is here to facilitate docker image creation in circleci
+This `orb` is providing a bunch of repetitive and generic commands to help with the creation of `docker` images in `circleci`.
 
-It offers a few commands as described below: TBC
+The commands can be used to target the creation of multi arch images which can then be stored in your  container repository
+
+## Commands
+
+These are the defined commands in this `orb`
+### <u>clone</u>
+
+All scripts are stored in an internal `ovotech` [repo](https://github.com/ovotech/ohs-build-scripts) called `ohs-build-scripts`. This command can be used to clone that repo inside of your `circleci` pipeline to have them available to you.
+
+Parameters for this step:
+
+| name | description |
+| --- | --- |
+| `git_repo` | Git repository to clone |
+| `local_folder` | Local folder path where the git repo will be cloned to |
+
+### <u>build</u>
+
+The `build` command invokes the `build-image.sh` script to build your docker image in the targeted architecture. It uses `docker buildx` under the hood. 
+
+It is recommended that when you target a specific processor architecture (`amd64` or `arm64`) that you build it on a machine using the same architecture as otherwise `docker buildx` will use some emulation that could lead to very long build times.
+
+When you target multiple architectures at the same time, you can run parallel builds in `circleci` and save the images to a workspace. This is covered by the next command.
+
+Parameters for this step:
+
+| name | description | accepted values |
+| --- | --- | --- |
+| `architecture` | Targeted processor architecture desired | `arm64`, `amd64` |
+| `image_name` | Docker image name |
+| `docker_registry` | Docker registry |
+| `docker_file` | Docker file name + location |
+| `clone_folder` | Clone build-script folder |
+
+### <u>save-image</u>
+
+This step can be used to save your docker images to a `circleci` [workspace](https://circleci.com/docs/workspaces/)
+
+Parameters for this step:
+
+| name | description |
+| --- | --- |
+| `image_name` | Docker image name to save |
+| `path_name` | Path name where the image will be saved |
+| `root_name` | Root folder name where the image will be saved |
+
+This will use the `docker save` command that will create a `.tar` file
+
+### <u>restore_images</u>
+
+Restores all images saved in a `circleci` workspace. 
+
+Parameters for this step:
+
+| name | description |
+| --- | --- |
+| `path_name` | Path name where the image will be loaded from |
+| `root_name` | Root folder name where the image will be loaded from |
+
+## Example configuration that use that `orb`
+
+The [Customer signup](https://github.com/ovotech/homeservices-customer-signup/blob/main/.circleci/config.yml) API `config.yml` file is one example of that orb being used. 
+
+It shows how a multi arch image is created for `arm64` and `amd64` based processors and to use the steps described here.
+
+## Executors
+
+This orb does not define any executors. It only provides re-usable commands

--- a/build-utilities/README.md
+++ b/build-utilities/README.md
@@ -1,0 +1,5 @@
+#Build utilities
+
+This orb is here to facilitate docker image creation in circleci
+
+It offers a few commands as described below: TBC

--- a/build-utilities/orb.yml
+++ b/build-utilities/orb.yml
@@ -3,6 +3,7 @@ description: "Build utilities"
 
 commands:
   clone-utilities:
+    description: 'Clones the utilities repo into the current process'
     parameters:
       git_repo:
         description: "Git repository to clone"
@@ -20,14 +21,19 @@ commands:
             chmod +x << parameters.local_folder >>/docker/publish-manifest.sh
 
   build:
+    description: 'Executes the build utility script to build docker images in the targeted processor architecture'
     parameters:
       architecture: 
+        description: "Target processor architecture (amd64, arm64) desired"
         type: string
       image_name:
+        description: "Docker image name"
         type: string
       docker_registry:
+        description: "Docker registry"
         type: string
       docker_file:
+        description: "Docker file name + location"
         type: string
     steps:
       - checkout
@@ -47,12 +53,16 @@ commands:
                 DOCKER_REGISTRY=<< parameters.docker_registry >>
 
   save-image:
+    description: 'Saves container images to the circleci workspace'
     parameters:
       image_name: 
+        description: "Filename to save image using docker"
         type: string
       path_name:
+        description: "Path name where the image will be saved"
         type: string
       root_name:
+        description: "Root folder name where the image will be saved"
         type: string
     steps:
       - run:
@@ -67,6 +77,13 @@ commands:
 
   restore_persisted_container_images:
     description: 'Restores container images saved to the workspace to the current docker context'
+    parameters:
+      path_name:
+        description: "Path name where the image will be lloaded from"
+        type: string
+      root_name:
+        description: "Root folder name where the image will be loaded from"
+        type: string
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/build-utilities/orb.yml
+++ b/build-utilities/orb.yml
@@ -1,0 +1,78 @@
+version: 2.1
+description: "OHS build utilities"
+
+commands:
+  clone-utilities:
+    parameters:
+      git_repo:
+        description: "Git repository to clone"
+        type: string
+      local_folder:
+        description: "Local folder path where the git repo will be cloned to"
+        type: string
+    steps:
+      - run:
+          name: Clone repo
+          command: |
+            mkdir << parameters.local_folder >>
+            git clone << parameters.git_repo >> << parameters.local_folder >>
+            chmod +x << parameters.local_folder >>/docker/build-image.sh
+            chmod +x << parameters.local_folder >>/docker/publish-manifest.sh
+
+  build:
+    parameters:
+      architecture: 
+        type: string
+      image_name:
+        type: string
+      docker_registry:
+        type: string
+      docker_file:
+        type: string
+    steps:
+      - checkout
+      - clone-utilities:
+          git_repo: https://github.com/ovotech/ohs-build-scripts.git
+          local_folder: $HOME/utilities
+      - run:
+          name: Build image
+          working_directory: src
+          command: |
+            $HOME/utilities/docker/build-image.sh \
+                TARGET_ARCH=<< parameters.architecture >>\
+                NUGET_USERNAME=$NUGET_USERNAME\
+                NUGET_PASSWORD=$NUGET_PASSWORD\
+                DOCKERFILE=<< parameters.docker_file >>\
+                IMAGE_NAME=<< parameters.image_name >>\
+                DOCKER_REGISTRY=<< parameters.docker_registry >>
+
+  save-image:
+    parameters:
+      image_name: 
+        type: string
+      path_name:
+        type: string
+      root_name:
+        type: string
+    steps:
+      - run:
+          name: Archive image
+          command: |
+            mkdir -p << parameters.root_name >>/<< parameters.path_name >>
+            docker save -o << parameters.root_name >>/<< parameters.path_name >>/<< parameters.image_name >>.tar << parameters.image_name >>
+      - persist_to_workspace:
+          root: << parameters.root_name >>
+          paths:
+            - << parameters.path_name >>
+
+  restore_persisted_container_images:
+    description: 'Restores container images saved to the workspace to the current docker context'
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Load images into docker
+          command: |
+            for i in /tmp/workspace/container_images/*.tar; do
+              docker load -i "$i"
+            done 

--- a/build-utilities/orb.yml
+++ b/build-utilities/orb.yml
@@ -24,7 +24,7 @@ commands:
     description: 'Executes the build utility script to build docker images in the targeted processor architecture'
     parameters:
       architecture: 
-        description: "Target processor architecture (amd64, arm64) desired"
+        description: "Targeted processor architecture (amd64, arm64) desired"
         type: string
       image_name:
         description: "Docker image name"
@@ -35,11 +35,15 @@ commands:
       docker_file:
         description: "Docker file name + location"
         type: string
+      clone_folder:
+        description: "Clone build-script folder"
+        type: string
+        default: $HOME/utilities
     steps:
       - checkout
       - clone:
           git_repo: https://github.com/ovotech/ohs-build-scripts.git
-          local_folder: $HOME/utilities
+          local_folder: << parameters.clone_folder >>
       - run:
           name: Build image
           working_directory: src
@@ -56,7 +60,7 @@ commands:
     description: 'Saves container images to the circleci workspace'
     parameters:
       image_name: 
-        description: "Filename to save image using docker"
+        description: "Docker image name to save"
         type: string
       path_name:
         description: "Path name where the image will be saved"
@@ -79,7 +83,7 @@ commands:
     description: 'Restores container images saved in the workspace to the current docker context'
     parameters:
       path_name:
-        description: "Path name where the image will be lloaded from"
+        description: "Path name where the image will be loaded from"
         type: string
       root_name:
         description: "Root folder name where the image will be loaded from"

--- a/build-utilities/orb.yml
+++ b/build-utilities/orb.yml
@@ -1,5 +1,5 @@
 version: 2.1
-description: "OHS build utilities"
+description: "Build utilities"
 
 commands:
   clone-utilities:

--- a/build-utilities/orb.yml
+++ b/build-utilities/orb.yml
@@ -37,7 +37,7 @@ commands:
         type: string
     steps:
       - checkout
-      - clone-utilities:
+      - clone:
           git_repo: https://github.com/ovotech/ohs-build-scripts.git
           local_folder: $HOME/utilities
       - run:

--- a/build-utilities/orb.yml
+++ b/build-utilities/orb.yml
@@ -1,21 +1,8 @@
 version: 2.1
 description: "Build utilities"
 
-defaults: &defaults
-  working_directory: ~/project
-
-amd64: &amd64
-  <<: *defaults
-  machine:
-    image: ubuntu-2004:current
-    docker_layer_caching: true
-
-arm64: &arm64
-  <<: *amd64
-  resource_class: arm.medium
-
 commands:
-  clone-utilities:
+  clone:
     description: 'Clones the utilities repo into the current process'
     parameters:
       git_repo:
@@ -88,8 +75,8 @@ commands:
           paths:
             - << parameters.path_name >>
 
-  restore_persisted_container_images:
-    description: 'Restores container images saved to the workspace to the current docker context'
+  restore_images:
+    description: 'Restores container images saved in the workspace to the current docker context'
     parameters:
       path_name:
         description: "Path name where the image will be lloaded from"

--- a/build-utilities/orb.yml
+++ b/build-utilities/orb.yml
@@ -1,6 +1,19 @@
 version: 2.1
 description: "Build utilities"
 
+defaults: &defaults
+  working_directory: ~/project
+
+amd64: &amd64
+  <<: *defaults
+  machine:
+    image: ubuntu-2004:current
+    docker_layer_caching: true
+
+arm64: &arm64
+  <<: *amd64
+  resource_class: arm.medium
+
 commands:
   clone-utilities:
     description: 'Clones the utilities repo into the current process'

--- a/build-utilities/orb.yml
+++ b/build-utilities/orb.yml
@@ -86,10 +86,10 @@ commands:
         type: string
     steps:
       - attach_workspace:
-          at: /tmp/workspace
+          at: << parameters.root_name >>
       - run:
           name: Load images into docker
           command: |
-            for i in /tmp/workspace/container_images/*.tar; do
+            for i in /<< parameters.root_name >>/<< parameters.path_name >>/*.tar; do
               docker load -i "$i"
             done 

--- a/build-utilities/orb_version.txt
+++ b/build-utilities/orb_version.txt
@@ -1,0 +1,1 @@
+@ovotech/build-utilities@0.1.0

--- a/build-utilities/orb_version.txt
+++ b/build-utilities/orb_version.txt
@@ -1,1 +1,1 @@
-@ovotech/build-utilities@0.1.0
+@ovotech/build-utilities@0.1.1


### PR DESCRIPTION
New `orb` called `build-utilities` which contains a bunch of repetitive commands in our `config.yml`
This should open access to a getting - from another internal repo - a set of internal `bash` scripts used to create multi-arch images and store them in a manifest to a private docker registry.
Tested `orb` in a project - https://app.circleci.com/pipelines/github/ovotech/homeservices-customer-signup?branch=CGI-20520-add-orb

