### PR TITLE
Updates rac-gcp-deploy

### DIFF
--- a/rac-gcp-deploy/orb.yml
+++ b/rac-gcp-deploy/orb.yml
@@ -167,6 +167,10 @@ commands:
       snyk-project-name:
         description: "Name of the target Snyk project"
         type: string
+      monitor-on-build:
+        description: "Take a current application dependencies snapshot for continuous monitoring by Snyk, if test was successful."
+        type: boolean
+        default: false
     steps:
       - snyk/scan:
           # Do not fail builds while we bed this command in - but note that it may be enforced at some point.
@@ -177,8 +181,9 @@ commands:
           target-file: target/docker/stage/Dockerfile
           fail-on-issues: false
           severity-threshold: high
-          monitor-on-build: false
+          monitor-on-build: <<parameters.monitor-on-build>>
           project: <<parameters.snyk-project-name>>
+          organization: reads-and-consumption
 
 jobs:
   compile:

--- a/rac-gcp-deploy/orb.yml
+++ b/rac-gcp-deploy/orb.yml
@@ -15,7 +15,7 @@ aliases:
   google-compute-zone: <<parameters.google-compute-zone>>
 
 orbs:
-  snyk: snyk/snyk@1.1.2
+  snyk: snyk/snyk@1.4.0
   aws-ecr: circleci/aws-ecr@7.2.0
 
 executors:
@@ -174,6 +174,7 @@ commands:
           # result in a duplicate Snyk project for the image, as our Kubernetes integration uses a project
           # name that incorporates the namespace & object type (and so is likely to differ from snyk-project-name).
           docker-image-name: <<parameters.docker-image-name>>
+          target-file: target/docker/stage/Dockerfile
           fail-on-issues: false
           severity-threshold: high
           monitor-on-build: false

--- a/rac-gcp-deploy/orb_version.txt
+++ b/rac-gcp-deploy/orb_version.txt
@@ -1,0 +1,1 @@
+ovotech/rac-gcp-deploy@1.1.0


### PR DESCRIPTION
* [Adds target-file](https://github.com/ovotech/circleci-orbs/commit/5d318fc48bca91326c1e8cdf048202f56baa62bd) Since c&e projects don't have a standard Dockerfile in root, snyk won't be able to auto-detect it and provide base image remediation advice.

* [Exposes monitor-on-build parameter](https://github.com/ovotech/circleci-orbs/commit/f9d8fabb5b6b826fe61f6cc13087c921e881174c)