### PR TITLE
Updates rac-kmi-deploy

### DIFF
--- a/rac-kmi-deploy/orb.yml
+++ b/rac-kmi-deploy/orb.yml
@@ -6,7 +6,7 @@ aliases:
 
 orbs:
   aws-ecr: circleci/aws-ecr@7.2.0
-  core: ovotech/rac-gcp-deploy@1
+  core: ovotech/rac-gcp-deploy@1.1.0
 
 executors:
   docker:
@@ -77,6 +77,10 @@ jobs:
             # sbt unconditionally builds image tagged as nonprod
             docker save -o <<parameters.workspace-dir>>/$<<parameters.container-name>>.dockerimage $<<parameters.container-name>>
       - core/snyk_monitor
+      - core/snyk_scan_image:
+          docker-image-name: $<<parameters.container-name>>
+          snyk-project-name: CIRCLE_PROJECT_REPONAME
+          monitor-on-build: true
       - core/persist_workspace:
           to: <<parameters.workspace-dir>>
 

--- a/rac-kmi-deploy/orb_version.txt
+++ b/rac-kmi-deploy/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/rac-kmi-deploy@1.0.2
+ovotech/rac-kmi-deploy@1.1.0


### PR DESCRIPTION
⚠️ Depends on #506
At the point where we add snyk monitoring of project dependencies, we now also monitor the container

~After https://github.com/ovotech/circleci-orbs/pull/506 is merged, core dependency can be updated to ovotech/rac-gcp-deploy@1.1.0~ ✅ 