### PR TITLE
Support timeout for Terraform

### DIFF
--- a/terraform-v2/apply.sh
+++ b/terraform-v2/apply.sh
@@ -28,7 +28,13 @@ function update_status() {
 
 function apply() {
     set +e
-    terraform -chdir=${module_path} apply -input=false -no-color -auto-approve -lock-timeout=300s plan.out | $TFMASK
+
+    if [[ "<< parameters.timeout >>" -gt 0 ]]; then
+        timeout "<< parameters.timeout >>" terraform -chdir=${module_path} apply -input=false -no-color -auto-approve -lock-timeout=300s plan.out | $TFMASK
+    else
+        terraform -chdir=${module_path} apply -input=false -no-color -auto-approve -lock-timeout=300s plan.out | $TFMASK
+    fi
+
     local TF_EXIT=${PIPESTATUS[0]}
     set -e
 

--- a/terraform-v2/orb.yml
+++ b/terraform-v2/orb.yml
@@ -81,6 +81,11 @@ aliases:
         type: "string"
         description: "Path to the json file to save the output variables to"
         default: ""
+    timeout: &timeout
+      timeout:
+        type: "integer"
+        description: "Timeout in seconds applied to terraform apply. Default is 0 (no timeout)"
+        default: 0
 
   init-parameter-passthrough: &init-parameter-passthrough
     path: << parameters.path >>
@@ -152,6 +157,7 @@ commands:
       <<: *target
       <<: *output_path
       <<: *reuse_plan
+      <<: *timeout
     steps:
       - run:
           name: "terraform apply << parameters.path >> << parameters.label >>"


### PR DESCRIPTION
A number of teams are switching to using OIDC session tokens for their pipelines. Unlike the previously used IAM credentials these have a short duration (default 1 hour). If Terraform apply takes longer than the duration of the session token it will not be able to update remote state.

Although this is rare (typically when starting up a new environment) it is time consuming for teams to recover.

This PR adds the option to gracefully terminate Terraform after the specified period, and thus ensuring it does not try to run beyond the lifespan of the session tokens.