### PR TITLE
Downgrade snyk orb

### DIFF
--- a/rac-gcp-deploy/orb.yml
+++ b/rac-gcp-deploy/orb.yml
@@ -15,7 +15,7 @@ aliases:
   google-compute-zone: <<parameters.google-compute-zone>>
 
 orbs:
-  snyk: snyk/snyk@1.4.0
+  snyk: snyk/snyk@1.2.0
   aws-ecr: circleci/aws-ecr@7.2.0
 
 executors:

--- a/rac-gcp-deploy/orb_version.txt
+++ b/rac-gcp-deploy/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/rac-gcp-deploy@1.2.0
+ovotech/rac-gcp-deploy@1.2.1


### PR DESCRIPTION
v 1.3.0+  is returning a weird

```
Downloading Snyk CLI version 1.1076.0
snyk-linux: OK

We trust you have received the usual lecture from the local System
Administrator. It usually boils down to these three things:

    #1) Respect the privacy of others.
    #2) Think before you type.
    #3) With great power comes great responsibility.

[sudo] password for circleci:
sudo: no password was provided
sudo: a password is required

Exited with code exit status 1
```