### PR TITLE
Adds kmi-region param to deploy job

### DIFF
--- a/rac-kmi-deploy/orb.yml
+++ b/rac-kmi-deploy/orb.yml
@@ -132,6 +132,11 @@ jobs:
         description: "The environment of KMI to deploy to"
         type: string
         default: uat
+      kmi-region:
+        description: "The region of KMI to deploy to"
+        type: enum
+        default: all
+        enum: ["eu1", "ap1", "all"]
       version-field-name:
         description: "The field name of the value which contains the target version"
         type: string
@@ -158,7 +163,12 @@ jobs:
           name: Patch deployment
           command: |
             cd ~/gitops/<<parameters.kmi-application-name>>
-            yq e ".<<parameters.version-field-name>>=\"$(cat <<parameters.workspace-dir>>/version.txt)\"" -i values-<<parameters.kmi-env>>-shared.yaml
+            if [ "$<<parameters.kmi-region>>" = "all" ]; then 
+              yq e ".<<parameters.version-field-name>>=\"$(cat <<parameters.workspace-dir>>/version.txt)\"" -i values-<<parameters.kmi-env>>-ap1.yaml
+              yq e ".<<parameters.version-field-name>>=\"$(cat <<parameters.workspace-dir>>/version.txt)\"" -i values-<<parameters.kmi-env>>-eu1.yaml
+            else
+              yq e ".<<parameters.version-field-name>>=\"$(cat <<parameters.workspace-dir>>/version.txt)\"" -i values-<<parameters.kmi-env>>-<<parameters.kmi-region>>.yaml
+            fi
       - run:
           name: Commit and push
           command: |

--- a/rac-kmi-deploy/orb_version.txt
+++ b/rac-kmi-deploy/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/rac-kmi-deploy@1.1.0
+ovotech/rac-kmi-deploy@1.2.0


### PR DESCRIPTION
Currently, the EU1 UAT environment works as a development environment, very different to the OEA-owned AP1 UAT (Sandbox). Because of this, on a merge to main we will want to release automatically to EU1 UAT but not AP1 UAT, hence the introduction of a kmi-region parameter that allows us to release on specific regions.