### PR TITLE
Installs dockerize

### DIFF
--- a/rac-kmi-deploy/executor/Dockerfile
+++ b/rac-kmi-deploy/executor/Dockerfile
@@ -60,6 +60,14 @@ RUN set -ex \
 # Install docker compose
 RUN apk --update add --no-cache docker-compose
 
+# Install dockerize
+RUN apk add --no-cache openssl
+
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
 RUN id -u circleci 2> /dev/null || useradd --system --create-home --uid 1001 --gid 0 circleci
 
 WORKDIR /home/circleci


### PR DESCRIPTION
dockerize is a utility to simplify running applications in docker containers. It allows you to:

generate application configuration files at container startup time from templates and container environment variables Tail multiple log files to stdout and/or stderr
Wait for other services to be available using TCP, HTTP(S), unix before starting the main process.