### PR TITLE
OOT-2476 OIDC for oot-eks orb

### DIFF
--- a/oot-eks-oidc/README.md
+++ b/oot-eks-oidc/README.md
@@ -10,13 +10,13 @@ Provides commands for packaging images for deployment to [AWS EKS](https://aws.a
 
 ```yaml
 orbs:
-  oot-eks: ovotech/oot-eks-oidc@2.0.0
+  oot-eks-oidc: ovotech/oot-eks-oidc@2.0.0
 
 jobs:
   push-image-nonprod:
-    executor: oot-eks/aws
+    executor: oot-eks-oidc/aws
     steps:
-      - oot-eks/push-image:
+      - oot-eks-oidc/push-image:
           service: my-service
           account: "1234567890"
 ```

--- a/oot-eks-oidc/README.md
+++ b/oot-eks-oidc/README.md
@@ -1,0 +1,30 @@
+# OOT EKS Orb (OIDC Test) [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/ovotech/oot-eks-oidc)](https://circleci.com/orbs/registry/orb/ovotech/oot-eks-oidc)
+
+Provides commands for packaging images for deployment to [AWS EKS](https://aws.amazon.com/eks/).
+
+## Prerequisites
+
+- An [AWS ECR registry](https://aws.amazon.com/ecr/) with the same name as the service being deployed exists on the same AWS account.
+
+## Example
+
+```yaml
+orbs:
+  oot-eks: ovotech/oot-eks-oidc@2.0.0
+
+jobs:
+  push-image-nonprod:
+    executor: oot-eks/aws
+    steps:
+      - oot-eks/push-image:
+          service: my-service
+          account: "1234567890"
+```
+
+This is what will happen upon running the `push-image-nonprod` job:
+
+1. A new docker image is built from the current source.
+2. The image is scanned for vulnerabilities by Snyk.
+3. The image is pushed to an ECR registry called "my-service" within the AWS account 1234567890
+
+This orb tests switching aws deployment authentication away from an iam user and towards our OIDC provider.

--- a/oot-eks-oidc/orb.yml
+++ b/oot-eks-oidc/orb.yml
@@ -1,9 +1,9 @@
-version: 2.1
-description: "Opinionated commands for releasing OOT projects on AWS EKS via ECR."
+version: 1.0
+description: "Opinionated commands for releasing OOT projects on AWS EKS via ECR. Test to use an oidc provider."
 
 orbs:
-  aws-cli: circleci/aws-cli@1.4.1
-  aws-ecr: circleci/aws-ecr@6.15.3
+  aws-cli: circleci/aws-cli@3.1.4
+  aws-ecr: circleci/aws-ecr@8.2.1
   snyk: snyk/snyk@1.1.2
 
 commands:
@@ -50,11 +50,11 @@ commands:
 
       - aws-cli/install
       - aws-cli/setup:
-          aws-deploy-role-arn: << parameters.aws-deploy-role-arn >>
+          role-arn: << parameters.aws-deploy-role-arn >>
 
       - aws-ecr/build-image:
           account-url: AWS_ECR_ACCOUNT_URL
-          aws-deploy-role-arn: << parameters.aws-deploy-role-arn >>
+          role-arn: << parameters.aws-deploy-role-arn >>
 
           repo: << parameters.service >>
           tag: << parameters.image-tag >>,<< parameters.extra-image-tags >>

--- a/oot-eks-oidc/orb.yml
+++ b/oot-eks-oidc/orb.yml
@@ -1,0 +1,78 @@
+version: 2.1
+description: "Opinionated commands for releasing OOT projects on AWS EKS via ECR."
+
+orbs:
+  aws-cli: circleci/aws-cli@1.4.1
+  aws-ecr: circleci/aws-ecr@6.15.3
+  snyk: snyk/snyk@1.1.2
+
+commands:
+  push-image:
+    description: "Builds, scans and pushes a new service to ECR."
+    parameters:
+      service:
+        description: "The name of the service that will be deployed. This will be used to build up the image name."
+        type: string
+      aws-deploy-role-arn:
+        description: "Terraformed role arn for AWS access. Can be found from oot-infra terraform state."
+        type: string
+        default: AWS_DEPLOY_ROLE_ARN
+      account:
+        description: "The numeric identifier for the AWS account on which the operation will be run."
+        type: string
+        default: ${AWS_ACCOUNT}
+      region:
+        description: "The AWS region on which the operation will be run."
+        type: string
+        default: eu-west-1
+      extra-build-args:
+        description: "Extra arguments to pass when running docker build"
+        type: string
+        default: ""
+      image-tag:
+        description: "Tag to push the image with"
+        type: string
+        default: ${CIRCLE_SHA1}
+      extra-image-tags:
+        description: "Extra tags to push the image with, these will not be snyk scanned"
+        type: string
+        default: latest
+
+    steps:
+      - attach_workspace:
+          at: .
+
+      - run:
+          command: |
+            echo "export AWS_DEFAULT_REGION=<< parameters.region >>" >> $BASH_ENV
+            echo "export AWS_REGION=eu-west-1" >> $BASH_ENV
+            echo "export AWS_ECR_ACCOUNT_URL=<< parameters.account >>.dkr.ecr.<< parameters.region >>.amazonaws.com" >> $BASH_ENV
+
+      - aws-cli/install
+      - aws-cli/setup:
+          aws-deploy-role-arn: << parameters.aws-deploy-role-arn >>
+
+      - aws-ecr/build-image:
+          account-url: AWS_ECR_ACCOUNT_URL
+          aws-deploy-role-arn: << parameters.aws-deploy-role-arn >>
+
+          repo: << parameters.service >>
+          tag: << parameters.image-tag >>,<< parameters.extra-image-tags >>
+          ecr-login: true
+          extra-build-args: << parameters.extra-build-args >>
+
+      - snyk/scan:
+          monitor-on-build: true
+          severity-threshold: high
+          fail-on-issues: false
+          target-file: Dockerfile
+          docker-image-name: $AWS_ECR_ACCOUNT_URL/<< parameters.service >>:<< parameters.image-tag >>
+
+      - aws-ecr/push-image:
+          repo: << parameters.service >>
+          tag: << parameters.image-tag >>,<< parameters.extra-image-tags >>
+
+executors:
+  aws:
+    machine:
+      image: ubuntu-2004:202201-02

--- a/oot-eks-oidc/orb_version.txt
+++ b/oot-eks-oidc/orb_version.txt
@@ -1,0 +1,1 @@
+ovotech/oot-eks-oidc@1.0.0


### PR DESCRIPTION
Over in the Kaluza Agent Platform/Experience, Ops Tooling are looking to replace the IAM user with an OIDC provider in our oot-eks deploy orb. This is according to guidance from the sec eng team to remove aws iam users.

This PR sets up a temporary orb that we can use for testing this process.