### PR TITLE
OOT-2476 Add reg id to build and push steps

### DIFF
--- a/oot-eks-oidc/orb.yml
+++ b/oot-eks-oidc/orb.yml
@@ -58,6 +58,7 @@ commands:
           repo: << parameters.service >>
           tag: << parameters.image-tag >>,<< parameters.extra-image-tags >>
           extra-build-args: << parameters.extra-build-args >>
+          registry-id: AWS_ACCOUNT_ID
 
       - snyk/scan:
           monitor-on-build: true
@@ -69,6 +70,7 @@ commands:
       - aws-ecr/push-image:
           repo: << parameters.service >>
           tag: << parameters.image-tag >>,<< parameters.extra-image-tags >>
+          registry-id: AWS_ACCOUNT_ID
 
 executors:
   aws:


### PR DESCRIPTION
The deployment process is still upset about missing reg id. Perhaps this is on build and push instead of on login?