### PR TITLE
kap-kmi-deploy: add region param to job

### DIFF
--- a/kap-kmi-deploy/README.md
+++ b/kap-kmi-deploy/README.md
@@ -55,6 +55,7 @@ workflows:
           name: kmi-deploy-uat
           environment: uat
           push-image: true
+          kmi-region: eu1
       - kmi-deploy/deploy:
           name: kmi-deploy-prod
           environment: prod

--- a/kap-kmi-deploy/orb.yml
+++ b/kap-kmi-deploy/orb.yml
@@ -149,6 +149,10 @@ jobs:
         type: boolean
         description: "Whether a new image should be built and pushed. If false, it is assumed that the image has already been pushed."
         default: false
+      kmi-region:
+        type: string
+        description: "The KMI region to update gitops for. Defaults to updating all regions."
+        default: "*"
 
     steps:
       - when:
@@ -168,6 +172,7 @@ jobs:
           gitops-email: << parameters.gitops-email >>
           tag: << parameters.tag >>
           tag-line-match: << parameters.tag-line-match >>
+          kmi-region: << parameters.kmi-region >>
 
 executors:
   aws:

--- a/kap-kmi-deploy/orb_version.txt
+++ b/kap-kmi-deploy/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/kap-kmi-deploy@1.0.2
+ovotech/kap-kmi-deploy@1.1.2


### PR DESCRIPTION
Adds ability to specify which region (e.g. "eu1", "ap1") to update gitops on.

In Workflow we want to be able to release to oea-test and ovo-uat at the same time, have a manual approval step, and then progress the build to oea-sandbox and ovo-prod. We'd need to be able to specify the region to deploy to ovo-uat without affecting oea-sandbox (which is uat in git-ops).