### PR TITLE
JAWS orb: bump Snyk orb version

### DIFF
--- a/jaws-journey-deploy/changelog.md
+++ b/jaws-journey-deploy/changelog.md
@@ -1,3 +1,6 @@
+# 3.0.2
+* Bump Snyk orb version to get retries for the Snyk CLI download step in more cases
+
 # 3.0.1
 * Bump Snyk orb version to get retries for the Snyk CLI download step
 

--- a/jaws-journey-deploy/orb.yml
+++ b/jaws-journey-deploy/orb.yml
@@ -6,7 +6,7 @@ orbs:
   aws-ecr: circleci/aws-ecr@8.1.3
   terraform: ovotech/terraform-v2@2.4.17
   openjdk-install: cloudesire/openjdk-install@1.2.3
-  snyk: snyk/snyk@1.5.0
+  snyk: snyk/snyk@1.7.0
   shipit: ovotech/shipit@1
   slack: circleci/slack@4.1.3
   argocd: ovotech/argocd@1.1.0

--- a/jaws-journey-deploy/orb_version.txt
+++ b/jaws-journey-deploy/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/jaws-journey-deploy@3.0.1
+ovotech/jaws-journey-deploy@3.0.2


### PR DESCRIPTION
Bumping again to use the update where curl will retry downloading the Snyk CLI in more cases