### PR TITLE
generate clean terraform plan with only changes

### DIFF
--- a/terraform-v2/apply.sh
+++ b/terraform-v2/apply.sh
@@ -55,7 +55,7 @@ set +e
 
 if [[ "<< parameters.reuse_plan >>" == "false" ]]; then
     terraform -chdir=${module_path} plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS
-    terraform show -no-color plan.out \
+    cd ${module_path} && terraform show -no-color plan.out \
         | $TFMASK \
         | tee /dev/fd/3 \
         | $COMPACT_PLAN \

--- a/terraform-v2/apply.sh
+++ b/terraform-v2/apply.sh
@@ -54,11 +54,12 @@ set +e
 
 
 if [[ "<< parameters.reuse_plan >>" == "false" ]]; then
-    terraform -chdir=${module_path} plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS \
+    terraform -chdir=${module_path} plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS
+    terraform show -no-color plan.out \
         | $TFMASK \
         | tee /dev/fd/3 \
         | $COMPACT_PLAN \
-            >plan.txt
+        > plan.txt
 
     TF_EXIT=${PIPESTATUS[0]}
 

--- a/terraform-v2/apply.sh
+++ b/terraform-v2/apply.sh
@@ -55,11 +55,11 @@ set +e
 
 if [[ "<< parameters.reuse_plan >>" == "false" ]]; then
     terraform -chdir=${module_path} plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS
-    cd ${module_path} && terraform show -no-color plan.out \
+    (cd ${module_path} && terraform show -no-color plan.out \
         | $TFMASK \
         | tee /dev/fd/3 \
         | $COMPACT_PLAN \
-        > plan.txt
+    ) > plan.txt
 
     TF_EXIT=${PIPESTATUS[0]}
 

--- a/terraform-v2/apply.sh
+++ b/terraform-v2/apply.sh
@@ -56,12 +56,12 @@ set +e
 if [[ "<< parameters.reuse_plan >>" == "false" ]]; then
     terraform -chdir=${module_path} plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS
     TF_EXIT=$?
-    cd ${module_path}
+    (cd ${module_path};
     terraform show -no-color plan.out \
         | $TFMASK \
         | tee /dev/fd/3 \
         | $COMPACT_PLAN \
-     > ../plan.txt
+     ) > plan.txt
      
 
     cd -

--- a/terraform-v2/apply.sh
+++ b/terraform-v2/apply.sh
@@ -54,14 +54,23 @@ set +e
 
 
 if [[ "<< parameters.reuse_plan >>" == "false" ]]; then
-    terraform -chdir=${module_path} plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS
-    TF_EXIT=$?
-    (cd ${module_path};
-    terraform show -no-color plan.out \
-        | $TFMASK \
-        | tee /dev/fd/3 \
-        | $COMPACT_PLAN \
-     ) > plan.txt
+    if [[ "<< parameters.trim_plan >>" == "true" ]]; then
+      terraform -chdir=${module_path} plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS
+      TF_EXIT=$?
+      (cd ${module_path};
+      terraform show -no-color plan.out \
+          | $TFMASK \
+          | $COMPACT_PLAN \
+       ) > plan.txt
+    else
+      terraform -chdir=${module_path} plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS \
+              | $TFMASK \
+              | tee /dev/fd/3 \
+              | $COMPACT_PLAN \
+                  >plan.txt
+      
+          TF_EXIT=${PIPESTATUS[0]}
+    fi 
 
     
     if [[ $TF_EXIT -eq 1 ]]; then

--- a/terraform-v2/apply.sh
+++ b/terraform-v2/apply.sh
@@ -59,9 +59,11 @@ if [[ "<< parameters.reuse_plan >>" == "false" ]]; then
         | $TFMASK \
         | tee /dev/fd/3 \
         | $COMPACT_PLAN \
-    ) > plan.txt
+     > ../plan.txt \
+     ; exit ${PIPESTATUS[0]}
+    )
 
-    TF_EXIT=${PIPESTATUS[0]}
+    TF_EXIT=$?
 
     if [[ $TF_EXIT -eq 1 ]]; then
         update_status "Error creating plan in CircleCI Job [${CIRCLE_JOB}](${CIRCLE_BUILD_URL})"

--- a/terraform-v2/apply.sh
+++ b/terraform-v2/apply.sh
@@ -62,9 +62,7 @@ if [[ "<< parameters.reuse_plan >>" == "false" ]]; then
         | tee /dev/fd/3 \
         | $COMPACT_PLAN \
      ) > plan.txt
-     
 
-    cd -
     
     if [[ $TF_EXIT -eq 1 ]]; then
         update_status "Error creating plan in CircleCI Job [${CIRCLE_JOB}](${CIRCLE_BUILD_URL})"

--- a/terraform-v2/apply.sh
+++ b/terraform-v2/apply.sh
@@ -55,6 +55,7 @@ set +e
 
 if [[ "<< parameters.reuse_plan >>" == "false" ]]; then
     terraform -chdir=${module_path} plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS
+    TF_EXIT=$?
     cd ${module_path}
     terraform show -no-color plan.out \
         | $TFMASK \
@@ -63,7 +64,6 @@ if [[ "<< parameters.reuse_plan >>" == "false" ]]; then
      > ../plan.txt
      
 
-    TF_EXIT=${PIPESTATUS[0]}
     cd -
     
     if [[ $TF_EXIT -eq 1 ]]; then

--- a/terraform-v2/apply.sh
+++ b/terraform-v2/apply.sh
@@ -55,16 +55,17 @@ set +e
 
 if [[ "<< parameters.reuse_plan >>" == "false" ]]; then
     terraform -chdir=${module_path} plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS
-    (cd ${module_path} && terraform show -no-color plan.out \
+    cd ${module_path}
+    terraform show -no-color plan.out \
         | $TFMASK \
         | tee /dev/fd/3 \
         | $COMPACT_PLAN \
-     > ../plan.txt \
-     ; exit ${PIPESTATUS[0]}
-    )
+     > ../plan.txt
+     
 
-    TF_EXIT=$?
-
+    TF_EXIT=${PIPESTATUS[0]}
+    cd -
+    
     if [[ $TF_EXIT -eq 1 ]]; then
         update_status "Error creating plan in CircleCI Job [${CIRCLE_JOB}](${CIRCLE_BUILD_URL})"
         exit 1

--- a/terraform-v2/orb.yml
+++ b/terraform-v2/orb.yml
@@ -81,6 +81,11 @@ aliases:
         type: "string"
         description: "Path to the json file to save the output variables to"
         default: ""
+    trim_plan: &trim_plan
+      trim_plan:
+        type: "boolean"
+        description: "Generate plan from the plan.out file excluding the warnings and other console outputs e.g. Lock status"
+        default: false
 
   init-parameter-passthrough: &init-parameter-passthrough
     path: << parameters.path >>
@@ -126,6 +131,7 @@ commands:
       <<: *label
       <<: *add_github_comment
       <<: *target
+      <<: *trim_plan
     steps:
       - run:
           name: "terraform plan << parameters.path >> << parameters.label >>"
@@ -152,6 +158,7 @@ commands:
       <<: *target
       <<: *output_path
       <<: *reuse_plan
+      <<: *trim_plan
     steps:
       - run:
           name: "terraform apply << parameters.path >> << parameters.label >>"

--- a/terraform-v2/orb_version.txt
+++ b/terraform-v2/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform-v2@2.4.21
+ovotech/terraform-v2@2.5.0

--- a/terraform-v2/orb_version.txt
+++ b/terraform-v2/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform-v2@2.4.20
+ovotech/terraform-v2@2.4.21

--- a/terraform-v2/plan.sh
+++ b/terraform-v2/plan.sh
@@ -15,15 +15,15 @@ exec 3>&1
 set +e
 terraform -chdir=${module_path} plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS
 
-(cd ${module_path} && terraform show -no-color plan.out \
+cd ${module_path}
+terraform show -no-color plan.out \
     | $TFMASK \
     | tee /dev/fd/3 \
     | $COMPACT_PLAN \
-    > ../plan.txt \
-    ; exit ${PIPESTATUS[0]}
-)
-  
-readonly TF_EXIT=$?
+ > plan.txt
+readonly TF_EXIT=${PIPESTATUS[0]}
+cd -
+
 set -e
 
 if [[ $TF_EXIT -eq 1 ]]; then

--- a/terraform-v2/plan.sh
+++ b/terraform-v2/plan.sh
@@ -15,11 +15,11 @@ exec 3>&1
 set +e
 terraform -chdir=${module_path} plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS
 
-cd ${module_path} && terraform show -no-color plan.out \
+(cd ${module_path} && terraform show -no-color plan.out \
     | $TFMASK \
     | tee /dev/fd/3 \
     | $COMPACT_PLAN \
-    > plan.txt
+) > plan.txt
 
 readonly TF_EXIT=${PIPESTATUS[0]}
 set -e

--- a/terraform-v2/plan.sh
+++ b/terraform-v2/plan.sh
@@ -17,13 +17,12 @@ terraform -chdir=${module_path} plan -input=false -no-color -detailed-exitcode -
 
 readonly TF_EXIT=$?
 
-cd ${module_path}
+(cd ${module_path};
 terraform show -no-color plan.out \
     | $TFMASK \
     | tee /dev/fd/3 \
     | $COMPACT_PLAN \
- > plan.txt
-cd -
+ ) > plan.txt
 
 set -e
 

--- a/terraform-v2/plan.sh
+++ b/terraform-v2/plan.sh
@@ -15,13 +15,14 @@ exec 3>&1
 set +e
 terraform -chdir=${module_path} plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS
 
+readonly TF_EXIT=$?
+
 cd ${module_path}
 terraform show -no-color plan.out \
     | $TFMASK \
     | tee /dev/fd/3 \
     | $COMPACT_PLAN \
  > plan.txt
-readonly TF_EXIT=${PIPESTATUS[0]}
 cd -
 
 set -e

--- a/terraform-v2/plan.sh
+++ b/terraform-v2/plan.sh
@@ -19,9 +19,11 @@ terraform -chdir=${module_path} plan -input=false -no-color -detailed-exitcode -
     | $TFMASK \
     | tee /dev/fd/3 \
     | $COMPACT_PLAN \
-) > plan.txt
-
-readonly TF_EXIT=${PIPESTATUS[0]}
+    > ../plan.txt \
+    ; exit ${PIPESTATUS[0]}
+)
+  
+readonly TF_EXIT=$?
 set -e
 
 if [[ $TF_EXIT -eq 1 ]]; then

--- a/terraform-v2/plan.sh
+++ b/terraform-v2/plan.sh
@@ -13,16 +13,24 @@ EOF
 exec 3>&1
 
 set +e
-terraform -chdir=${module_path} plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS
 
-readonly TF_EXIT=$?
-
-(cd ${module_path};
-terraform show -no-color plan.out \
-    | $TFMASK \
-    | tee /dev/fd/3 \
-    | $COMPACT_PLAN \
- ) > plan.txt
+if [[ "<< parameters.trim_plan >>" == "true" ]]; then
+  terraform -chdir=${module_path} plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS
+  readonly TF_EXIT=$?
+  (cd ${module_path};
+  terraform show -no-color plan.out \
+      | $TFMASK \
+      | $COMPACT_PLAN \
+   ) > plan.txt
+else
+  terraform -chdir=${module_path} plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS \
+          | $TFMASK \
+          | tee /dev/fd/3 \
+          | $COMPACT_PLAN \
+              >plan.txt
+  
+  readonly TF_EXIT=${PIPESTATUS[0]}
+fi
 
 set -e
 

--- a/terraform-v2/plan.sh
+++ b/terraform-v2/plan.sh
@@ -15,7 +15,7 @@ exec 3>&1
 set +e
 terraform -chdir=${module_path} plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS
 
-terraform show -no-color plan.out \
+cd ${module_path} && terraform show -no-color plan.out \
     | $TFMASK \
     | tee /dev/fd/3 \
     | $COMPACT_PLAN \

--- a/terraform-v2/plan.sh
+++ b/terraform-v2/plan.sh
@@ -13,11 +13,13 @@ EOF
 exec 3>&1
 
 set +e
-terraform -chdir=${module_path} plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS \
+terraform -chdir=${module_path} plan -input=false -no-color -detailed-exitcode -lock-timeout=300s -out=plan.out $PLAN_ARGS
+
+terraform show -no-color plan.out \
     | $TFMASK \
     | tee /dev/fd/3 \
     | $COMPACT_PLAN \
-        >plan.txt
+    > plan.txt
 
 readonly TF_EXIT=${PIPESTATUS[0]}
 set -e


### PR DESCRIPTION
# TL;DR

This PR addresses various issues occurring when:
-  terraform plan is generated, 
- posted to Git 
- and comapred before applying

Causes of 'Plan has changed' issue in various scenarios:
1. Plan has `Releasing state lock. This may take a few moments...` in either git comment or in the plan generated before apply for comparing with git comment
2. Warning in the plan: There can be multiple terraform resources of same type having same warning, terraform reports warning for the first resource it tried to refresh and this first resource could be any any one of the same resources (not same one due to parallel processing)
 hence causes plan has changed issue.

## Changes

- Generating the `plan.txt` file from the terraform's plan.out file instead of the console output of `terraform plan` command. This ensures that only the plan (add, change and destroy) is included in the git comment. 
- Added a boolean flag `trim_plan` to disable or enable this trimmed version of plan.

## Tests
I have manually verified the plan.txt files in above scenarios.
Also tested the dev version of the orb as part of this [PR](https://github.com/ovotech/retail-autocapture-auxiliary-config/pull/56)
Also tested when there is no change, it generates simple message
```text

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```