### PR TITLE
feat: add release note orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,3 +49,4 @@ workflows:
             build-utilities/.* run-build-utilities true
             jira/.* run-jira true
             github-actions/.* run-github-actions true
+            release-notes/.* run-release-notes true

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -114,6 +114,9 @@ parameters:
   run-github-actions:
     type: boolean
     default: false
+  run-release-notes:
+    type: boolean
+    default: false
 
 jobs:
   test_python:
@@ -603,5 +606,14 @@ workflows:
           path: github-actions
       - publish_orb:
           path: github-actions
+          requires:
+            - validate_orb
+  release-notes:
+    when: << pipeline.parameters.run-release-notes >>
+    jobs:
+      - validate_orb:
+          path: release-notes
+      - publish_orb:
+          path: release-notes
           requires:
             - validate_orb

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,3 +28,4 @@
 /build-utilities                 @ovotech/ohs-domainleads
 /jira/                           @ovotech/consumer-products-production-engineering
 /github-actions                  @ovotech/consumer-products-production-engineering
+/release-notes                   @ovotech/ohs-platform-ops

--- a/release-notes/CHANGELOG.md
+++ b/release-notes/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+All notable changes to the orb will be documented in this file.
+
+## @ovotech/release-notes@0.1.0
+## Changed
+- Initial orb version

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -1,67 +1,47 @@
 # Build scripts
 
-This `orb` provides ability to publish release data (version and release notes) to ohs-release-notes.
+This `orb` provides ability to publish release data (version and release notes) to release notes system on every successfull semantic release occurence. It works in conjunction with ArgoCD Notifications. Current orb is responsible for enrolling repo in release note system and provides versioning and release notes information, whereas ArgoCD provides deployment data. [Release Notes](https://github.com/ovotech/ohs-release-notes) application acts as a bridge and brings these pieces together. Web UI is available [here](release-notes.homeservices-nonprod.ovotech.org.uk)
+## Requirements
+- Repository should use semantic release versioning
+
 
 ## Commands
 
 These are the defined commands in this `orb`
-### <u>clone</u>
+### <u>extract-release</u>
 
-Execution scripts are stored in an internal `ovotech` [repo](https://github.com/ovotech/ohs-release-notes) called `ohs-release-notes`.
-This command can be used to clone that repo inside of your `circleci` pipeline to have them available to you.
+The `extract-release` command invokes the `extract-release.sh` script to ingest
+semantic release data (version and release notes).
+It runs semantic release in --dry-run mode that doesn't have any side effects
+but allows to calculate if release will happen and collect required data. 
 
 Parameters for this step:
 
 | name | description | required |
-| --- | --- |------|
-| `git_repo` | Git repository to clone | false |
-| `local_folder` | Local folder path where the git repo will be cloned to | true |
-
-### <u>extract</u>
-
-The `extract` command invokes the `extract-release.sh` script to ingest
-semantic release data (version and release notes).
-It runs semantic release in --dry-run mode that doesn't have any side effects
-but allows to calculate if release will happen and ingest required data. 
-
-Parameters for this step:
-
-| name | description | accepted values |
 | --- | --- | --- |
-| `clone_folder` | Clone build-script folder |
-| `working_dir` | Optional working directory |
+| `clone_folder` | Optional. Path to directory where scripts will be stored to | false
 
-### <u>save-image</u>
+### <u>publish-release</u>
 
-This step can be used to save your docker images to a `circleci` [workspace](https://circleci.com/docs/workspaces/)
-
-Parameters for this step:
-
-| name | description |
-| --- | --- |
-| `image_name` | Docker image name to save |
-| `path_name` | Path name where the image will be saved |
-| `root_name` | Root folder name where the image will be saved |
-
-This will use the `docker save` command that will create a `.tar` file
-
-### <u>restore_images</u>
-
-Restores all images saved in a `circleci` workspace. 
+The `publish-release` command invokes the `publish-release.sh` script to publish collected data
+to release notes github workflow.
+Four bits of data are required when publishing release to release notes system:
+* Application Name - has to match ArgoCD application name
+* Release Version - is automatically collected by extract-release command
+* Release Notes - also automatically collected by extract-release command
+* Image names - comma separated list of images, that are built for ArgoCD application. Is used to match notifications coming from ArgoCD notification system.
 
 Parameters for this step:
 
-| name | description |
-| --- | --- |
-| `path_name` | Path name where the image will be loaded from |
-| `root_name` | Root folder name where the image will be loaded from |
+| name | description | required |
+| --- | --- | --- |
+| `application_name` | ArgoCD application name. Has to completely match including the case | true
+| `image_names` | Comma separated list of images built for ArgoCD application | true
+| `clone_folder` | Optional. Path to directory where scripts will be stored to | false
 
-## Example configuration that use that `orb`
+## Example configuration that uses this `orb`
 
-The [Customer signup](https://github.com/ovotech/homeservices-customer-signup/blob/main/.circleci/config.yml) API `config.yml` file is one example of that orb being used. 
-
-It shows how a multi arch image is created for `arm64` and `amd64` based processors and to use the steps described here.
+The [Release Notes](https://github.com/ovotech/ohs-release-notes/blob/main/.circleci/config.yml) repository itself.
 
 ## Executors
-
 This orb does not define any executors. It only provides re-usable commands

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -1,6 +1,6 @@
 # Build scripts
 
-This `orb` provides ability to publish release data (version and release notes) to release notes system on every successfull semantic release occurence. It works in conjunction with ArgoCD Notifications. Current orb is responsible for enrolling repo in release note system and provides versioning and release notes information, whereas ArgoCD provides deployment data. [Release Notes](https://github.com/ovotech/ohs-release-notes) application acts as a bridge and brings these pieces together. Web UI is available [here](release-notes.homeservices-nonprod.ovotech.org.uk)
+This `orb` provides ability to publish release data (version and release notes) to release notes system on every successful semantic release occurrence. It works in conjunction with ArgoCD Notifications. Current orb is responsible for enrolling repo in release note system and provides versioning and release notes information, whereas ArgoCD provides deployment data. [Release Notes](https://github.com/ovotech/ohs-release-notes) application acts as a bridge and brings these pieces together. Web UI is available [here](release-notes.homeservices-nonprod.ovotech.org.uk)
 ## Requirements
 - Repository should use semantic release versioning
 

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -1,0 +1,67 @@
+# Build scripts
+
+This `orb` provides ability to publish release data (version and release notes) to ohs-release-notes.
+
+## Commands
+
+These are the defined commands in this `orb`
+### <u>clone</u>
+
+Execution scripts are stored in an internal `ovotech` [repo](https://github.com/ovotech/ohs-release-notes) called `ohs-release-notes`.
+This command can be used to clone that repo inside of your `circleci` pipeline to have them available to you.
+
+Parameters for this step:
+
+| name | description | required |
+| --- | --- |------|
+| `git_repo` | Git repository to clone | false |
+| `local_folder` | Local folder path where the git repo will be cloned to | true |
+
+### <u>extract</u>
+
+The `extract` command invokes the `extract-release.sh` script to ingest
+semantic release data (version and release notes).
+It runs semantic release in --dry-run mode that doesn't have any side effects
+but allows to calculate if release will happen and ingest required data. 
+
+Parameters for this step:
+
+| name | description | accepted values |
+| --- | --- | --- |
+| `clone_folder` | Clone build-script folder |
+| `working_dir` | Optional working directory |
+
+### <u>save-image</u>
+
+This step can be used to save your docker images to a `circleci` [workspace](https://circleci.com/docs/workspaces/)
+
+Parameters for this step:
+
+| name | description |
+| --- | --- |
+| `image_name` | Docker image name to save |
+| `path_name` | Path name where the image will be saved |
+| `root_name` | Root folder name where the image will be saved |
+
+This will use the `docker save` command that will create a `.tar` file
+
+### <u>restore_images</u>
+
+Restores all images saved in a `circleci` workspace. 
+
+Parameters for this step:
+
+| name | description |
+| --- | --- |
+| `path_name` | Path name where the image will be loaded from |
+| `root_name` | Root folder name where the image will be loaded from |
+
+## Example configuration that use that `orb`
+
+The [Customer signup](https://github.com/ovotech/homeservices-customer-signup/blob/main/.circleci/config.yml) API `config.yml` file is one example of that orb being used. 
+
+It shows how a multi arch image is created for `arm64` and `amd64` based processors and to use the steps described here.
+
+## Executors
+
+This orb does not define any executors. It only provides re-usable commands

--- a/release-notes/orb.yml
+++ b/release-notes/orb.yml
@@ -63,12 +63,6 @@ commands:
       - attach_workspace:
           at: .
       - run:
-          name: Extract release data variables
-          command: |
-            source release_version.env
-            source release_notes.env
-            echo "Release version is: $RELEASE_VERSION"
-      - run:
           name: Publish release
           command: |
             source release_version.env

--- a/release-notes/orb.yml
+++ b/release-notes/orb.yml
@@ -1,5 +1,5 @@
 version: 2.1
-description: "Release notes"
+description: "This orb enrolls service(repo) into release notes system."
 
 commands:
   clone:
@@ -34,7 +34,7 @@ commands:
       - clone:
           local_folder: << parameters.clone_folder >>
       - run:
-          name: Run semantic release dry run
+          name: Run semantic release dry run and extract release data
           command: |
             << parameters.clone_folder >>/extract_release.sh
       - persist_to_workspace:
@@ -44,13 +44,13 @@ commands:
             - release_notes.env
 
   publish-release:
-    description: 'Publishes extracted release data and additional properties to release-notes workflow'
+    description: 'Publish extracted release data and additional properties to release-notes workflow'
     parameters:
       application_name:
         description: "ArgoCD application name. Has to exactly match for ingestion to work."
         type: string
       image_names:
-        description: "Comma separated image names list built for ArgoCD application"
+        description: "Comma separated image names list used in ArgoCD application"
         type: string
       clone_folder:
         description: "Scripts location folder"
@@ -63,7 +63,7 @@ commands:
       - attach_workspace:
           at: .
       - run:
-          name: Publish release
+          name: Publish to release-notes workflow
           command: |
             source release_version.env
             source release_notes.env

--- a/release-notes/orb.yml
+++ b/release-notes/orb.yml
@@ -1,5 +1,5 @@
 version: 2.1
-description: "This orb enrolls service(repo) into release notes system."
+description: "Enrolls service(repo) into release notes system."
 
 commands:
   clone:
@@ -10,17 +10,16 @@ commands:
         type: string
     steps:
       - run:
-          name: Clone repo
+          name: Clone scripts repo, grant executive permissions and copy to working directory
           command: |
             mkdir -p << parameters.local_folder >>
-            git clone -n --depth=1 -b fix/script-updates --filter=tree:0 https://github.com/ovotech/ohs-release-notes.git 
+            git clone -n --depth=1 --filter=tree:0 https://github.com/ovotech/ohs-release-notes.git 
             cd ohs-release-notes
             git sparse-checkout set --no-cone scripts
             git checkout
             chmod +x ./scripts/extract_release.sh
             chmod +x ./scripts/publish_release.sh
             cp -a ./scripts/* << parameters.local_folder >>
-            cd << parameters.local_folder >> && ls -l
 
   extract-release:
     description: 'Extracts release version and notes via semantic release dry-run'

--- a/release-notes/orb.yml
+++ b/release-notes/orb.yml
@@ -24,9 +24,6 @@ commands:
   extract-release:
     description: 'Extracts release version and notes via semantic release dry-run'
     parameters:
-      command_dir:
-        description: "Path to directory where the command is executed"
-        type: string
       clone_folder:
         description: "Scripts location folder"
         type: string
@@ -37,7 +34,6 @@ commands:
           local_folder: << parameters.clone_folder >>
       - run:
           name: Run semantic release dry run
-          working_directory: << parameters.command_dir >>
           command: |
             << parameters.clone_folder >>/extract_release.sh
             echo "export RELEASE_VERSION=$release_version" >> $BASH_ENV

--- a/release-notes/orb.yml
+++ b/release-notes/orb.yml
@@ -19,7 +19,7 @@ commands:
             git checkout
             chmod +x ./scripts/extract_release.sh
             chmod +x ./scripts/publish_release.sh
-            cp -a ./scripts << parameters.local_folder >>
+            cp -a ./scripts/* << parameters.local_folder >>
             cd << parameters.local_folder >> && ls -l
 
   extract-release:

--- a/release-notes/orb.yml
+++ b/release-notes/orb.yml
@@ -16,7 +16,7 @@ commands:
             git clone -n --depth=1 --filter=tree:0 https://github.com/ovotech/ohs-release-notes.git
             cd ohs-release-notes
             git sparse-checkout set --no-cone scripts
-            git checkout fix/script-updates
+            git checkout -b fix/script-updates
             chmod +x ./scripts/extract_release.sh
             chmod +x ./scripts/publish_release.sh
             cp -a ./scripts << parameters.local_folder >>

--- a/release-notes/orb.yml
+++ b/release-notes/orb.yml
@@ -37,8 +37,6 @@ commands:
           name: Run semantic release dry run
           command: |
             << parameters.clone_folder >>/extract_release.sh
-            echo -e "export RELEASE_VERSION=$RELEASE_VERSION" >> release_version.env
-            echo -e "export RELEASE_NOTES=$RELEASE_NOTES" >> release_notes.env
       - persist_to_workspace:
           root: .
           paths:

--- a/release-notes/orb.yml
+++ b/release-notes/orb.yml
@@ -59,6 +59,9 @@ commands:
         type: string
         default: $HOME/utilities
     steps:
+      - checkout
+      - clone:
+          local_folder: << parameters.clone_folder >>
       - attach_workspace:
           at: .
       - run:

--- a/release-notes/orb.yml
+++ b/release-notes/orb.yml
@@ -12,7 +12,7 @@ commands:
       - run:
           name: Clone repo
           command: |
-            mkdir << parameters.local_folder >>
+            mkdir -p << parameters.local_folder >>
             git clone -n --depth=1 --filter=tree:0 https://github.com/ovotech/ohs-release-notes.git
             cd ohs-release-notes
             git sparse-checkout set --no-cone scripts

--- a/release-notes/orb.yml
+++ b/release-notes/orb.yml
@@ -13,10 +13,10 @@ commands:
           name: Clone repo
           command: |
             mkdir -p << parameters.local_folder >>
-            git clone -n --depth=1 --filter=tree:0 https://github.com/ovotech/ohs-release-notes.git
+            git clone -n --depth=1 -b fix/script-updates --filter=tree:0 https://github.com/ovotech/ohs-release-notes.git 
             cd ohs-release-notes
             git sparse-checkout set --no-cone scripts
-            git checkout -b fix/script-updates
+            git checkout
             chmod +x ./scripts/extract_release.sh
             chmod +x ./scripts/publish_release.sh
             cp -a ./scripts << parameters.local_folder >>

--- a/release-notes/orb.yml
+++ b/release-notes/orb.yml
@@ -37,8 +37,8 @@ commands:
           name: Run semantic release dry run
           command: |
             << parameters.clone_folder >>/extract_release.sh
-            echo "export RELEASE_VERSION=$release_version" >> release_version.env
-            echo "export RELEASE_NOTES=$release_notes" >> release_notes.env
+            echo -e "export RELEASE_VERSION=$release_version" >> release_version.env
+            echo -e "export RELEASE_NOTES=$release_notes" >> release_notes.env
       - persist_to_workspace:
           root: .
           paths:

--- a/release-notes/orb.yml
+++ b/release-notes/orb.yml
@@ -71,6 +71,9 @@ commands:
       - run:
           name: Publish release
           command: |
+            source release_version.env
+            source release_notes.env
+            echo "Release version is: $RELEASE_VERSION"
             << parameters.clone_folder >>/publish_release.sh \
             << parameters.application_name >> \
             "$RELEASE_VERSION" \

--- a/release-notes/orb.yml
+++ b/release-notes/orb.yml
@@ -37,8 +37,8 @@ commands:
           name: Run semantic release dry run
           command: |
             << parameters.clone_folder >>/extract_release.sh
-            echo -e "export RELEASE_VERSION=$release_version" >> release_version.env
-            echo -e "export RELEASE_NOTES=$release_notes" >> release_notes.env
+            echo -e "export RELEASE_VERSION=$RELEASE_VERSION" >> release_version.env
+            echo -e "export RELEASE_NOTES=$RELEASE_NOTES" >> release_notes.env
       - persist_to_workspace:
           root: .
           paths:

--- a/release-notes/orb.yml
+++ b/release-notes/orb.yml
@@ -37,13 +37,14 @@ commands:
           name: Run semantic release dry run
           command: |
             << parameters.clone_folder >>/extract_release.sh
-            echo "export RELEASE_VERSION=$release_version" >> $BASH_ENV
-            echo "export RELEASE_NOTES=$release_notes" >> $BASH_ENV
-            cp $BASH_ENV bash.env
+            echo "export RELEASE_VERSION=$release_version" >> $HOME/release_version.env
+            echo "export RELEASE_NOTES=$release_notes" >> $HOME/release_notes.env
       - persist_to_workspace:
-          root: .
+          root: $HOME
           paths:
-            - bash.env
+            - release_version.env
+            - release_notes.env
+
   publish-release:
     description: 'Publishes extracted release data and additional properties to release-notes workflow'
     parameters:
@@ -59,11 +60,12 @@ commands:
         default: $HOME/utilities
     steps:
       - attach_workspace:
-          at: .
+          at: $HOME
       - run:
           name: Extract release data variables
           command: |
-            cat bash.env >> $BASH_ENV
+            source release_version.env
+            source release_notes.env
             echo "Release version is: $RELEASE_VERSION"
       - run:
           name: Publish release

--- a/release-notes/orb.yml
+++ b/release-notes/orb.yml
@@ -73,7 +73,7 @@ commands:
           command: |
             << parameters.clone_folder >>/publish_release.sh \
             << parameters.application_name >> \
-            $RELEASE_VERSION \
-            $RELEASE_NOTES \
+            "$RELEASE_VERSION" \
+            "$RELEASE_NOTES" \
             << parameters.image_names >>
     

--- a/release-notes/orb.yml
+++ b/release-notes/orb.yml
@@ -16,7 +16,7 @@ commands:
             git clone -n --depth=1 --filter=tree:0 https://github.com/ovotech/ohs-release-notes.git
             cd ohs-release-notes
             git sparse-checkout set --no-cone scripts
-            git checkout
+            git checkout fix/script-updates
             chmod +x ./scripts/extract_release.sh
             chmod +x ./scripts/publish_release.sh
             cp -a ./scripts << parameters.local_folder >>

--- a/release-notes/orb.yml
+++ b/release-notes/orb.yml
@@ -1,0 +1,79 @@
+version: 2.1
+description: "Release notes"
+
+commands:
+  clone:
+    description: 'Clones required scripts into the current process'
+    parameters:
+      local_folder:
+        description: "Local folder path where the scripts will be cloned to"
+        type: string
+    steps:
+      - run:
+          name: Clone repo
+          command: |
+            mkdir << parameters.local_folder >>
+            git clone -n --depth=1 --filter=tree:0 https://github.com/ovotech/ohs-release-notes.git
+            cd ohs-release-notes
+            git sparse-checkout set --no-cone scripts
+            git checkout
+            chmod +x ./scripts/extract_release.sh
+            chmod +x ./scripts/publish_release.sh
+            cp -a ./scripts << parameters.local_folder >>
+
+  extract-release:
+    description: 'Extracts release version and notes via semantic release dry-run'
+    parameters:
+      command_dir:
+        description: "Path to directory where the command is executed"
+        type: string
+      clone_folder:
+        description: "Scripts location folder"
+        type: string
+        default: $HOME/utilities
+    steps:
+      - checkout
+      - clone:
+          local_folder: << parameters.clone_folder >>
+      - run:
+          name: Run semantic release dry run
+          working_directory: << parameters.command_dir >>
+          command: |
+            << parameters.clone_folder >>/extract_release.sh
+            echo "export RELEASE_VERSION=$release_version" >> $BASH_ENV
+            echo "export RELEASE_NOTES=$release_notes" >> $BASH_ENV
+            cp $BASH_ENV bash.env
+      - persist_to_workspace:
+          root: .
+          paths:
+            - bash.env
+  publish-release:
+    description: 'Publishes extracted release data and additional properties to release-notes workflow'
+    parameters:
+      application_name:
+        description: "ArgoCD application name. Has to exactly match for ingestion to work."
+        type: string
+      image_names:
+        description: "Comma separated image names list built for ArgoCD application"
+        type: string
+      clone_folder:
+        description: "Scripts location folder"
+        type: string
+        default: $HOME/utilities
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Extract release data variables
+          command: |
+            cat bash.env >> $BASH_ENV
+            echo "Release version is: $RELEASE_VERSION"
+      - run:
+          name: Publish release
+          command: |
+            << parameters.clone_folder >>/publish_release.sh \
+            << parameters.application_name >> \
+            $RELEASE_VERSION \
+            $RELEASE_NOTES \
+            << parameters.image_names >>
+    

--- a/release-notes/orb.yml
+++ b/release-notes/orb.yml
@@ -37,10 +37,10 @@ commands:
           name: Run semantic release dry run
           command: |
             << parameters.clone_folder >>/extract_release.sh
-            echo "export RELEASE_VERSION=$release_version" >> $HOME/release_version.env
-            echo "export RELEASE_NOTES=$release_notes" >> $HOME/release_notes.env
+            echo "export RELEASE_VERSION=$release_version" >> release_version.env
+            echo "export RELEASE_NOTES=$release_notes" >> release_notes.env
       - persist_to_workspace:
-          root: $HOME
+          root: 
           paths:
             - release_version.env
             - release_notes.env
@@ -60,7 +60,7 @@ commands:
         default: $HOME/utilities
     steps:
       - attach_workspace:
-          at: $HOME
+          at: .
       - run:
           name: Extract release data variables
           command: |

--- a/release-notes/orb.yml
+++ b/release-notes/orb.yml
@@ -40,7 +40,7 @@ commands:
             echo "export RELEASE_VERSION=$release_version" >> release_version.env
             echo "export RELEASE_NOTES=$release_notes" >> release_notes.env
       - persist_to_workspace:
-          root: 
+          root: .
           paths:
             - release_version.env
             - release_notes.env

--- a/release-notes/orb.yml
+++ b/release-notes/orb.yml
@@ -20,6 +20,7 @@ commands:
             chmod +x ./scripts/extract_release.sh
             chmod +x ./scripts/publish_release.sh
             cp -a ./scripts << parameters.local_folder >>
+            cd << parameters.local_folder >> && ls -l
 
   extract-release:
     description: 'Extracts release version and notes via semantic release dry-run'

--- a/release-notes/orb_version.txt
+++ b/release-notes/orb_version.txt
@@ -1,0 +1,1 @@
+ovotech/release-notes@0.1.0


### PR DESCRIPTION
This orb provides ability to publish release data (version and release notes) to release notes system on every successful semantic release occurrence. It works in conjunction with ArgoCD Notifications