### PR TITLE
Add Team CPPE as repo codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-*                                @ovotech/production-eng
+*                                @ovotech/production-eng @ovotech/consumer-products-production-engineering
 /terraform/                      @ovotech/production-eng
 /clair-scanner/                  @ovotech/production-eng
 /aws-rotate-keys/                @mwz


### PR DESCRIPTION
This PR adds Team CPPE to the CODEOWNERs file, allowing us to approve new orbs