### PR TITLE
feat: add explicit content-type

### DIFF
--- a/argocd/README.md
+++ b/argocd/README.md
@@ -14,7 +14,7 @@ The `target` must be the commmit hash you expect ArgoCD to sync with.
 
 ```yaml
 orbs:
-  argocd: ovotech/argocd@0.1.0
+  argocd: ovotech/argocd@1.2.0
 
 jobs:
   deploy-to-uat:

--- a/argocd/orb_version.txt
+++ b/argocd/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/argocd@1.1.0
+ovotech/argocd@1.2.0

--- a/argocd/scripts/wait_for_sync.py
+++ b/argocd/scripts/wait_for_sync.py
@@ -10,7 +10,7 @@ import os
 def sync_request(endpoint, token, application):
 
     try:
-        headers = { 'Authorization' : 'Bearer %s' % token }
+        headers = { 'Authorization' : 'Bearer %s' % token, 'Content-Type' : 'application/json' }
         res = requests.post(endpoint.rstrip("/") + f'/api/v1/applications/{application}/sync', headers=headers, timeout = 10, verify=True)
         if res.status_code != 200:
             print(f"ERROR: Non-200 response ({res.status_code}): {res.json()}.")
@@ -41,7 +41,7 @@ def sync_request(endpoint, token, application):
 def is_cluster_insync(endpoint, token, application, target_revision):
 
     try:
-        headers = { 'Authorization' : 'Bearer %s' % token }
+        headers = { 'Authorization' : 'Bearer %s' % token, 'Content-Type' : 'application/json' }
         res = requests.get(endpoint.rstrip("/") + f'/api/v1/applications/{application}', headers=headers, timeout = 10, verify=True)
         if res.status_code != 200:
             print(f"ERROR: Non-200 response ({res.status_code}): {res.json()}.")


### PR DESCRIPTION
With newer versions from argocd, without the explicit content type the json will be unreadable.

Similar work was done for the GitHub actions in [this PR](https://github.com/ovotech/kaluza-github-actions/pull/56/files).