### PR TITLE
include tf provider v1.9.9

### DIFF
--- a/terraform-v2/CHANGELOG.md
+++ b/terraform-v2/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
 not listed
 
+## ovotech/terraform-v2@2.5.5
+- Added legacy ovo kafka users v1.1.0 and v1.9.9 (end-of-life) to all executors
+
 ## ovotech/terraform-v2@2.5.1
 - Hide Terraform encryption key in Github comments
 

--- a/terraform-v2/orb_version.txt
+++ b/terraform-v2/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform-v2@2.5.4
+ovotech/terraform-v2@2.5.5

--- a/terraform/CHANGELOG.md
+++ b/terraform/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
 not listed
 
+## ovotech/terraform@1.11.21
+- Added legacy ovo kafka users v1.1.0 and v1.9.9 (end-of-life) to all executors
+
+## ovotech/terraform@1.11.20
+- Updated GCloud version from 329.0.0 to 463.0.0
+
 ## ovotech/terraform@1.11.19
 - Added Terraform provider Aiven Kafka Users v1.1.1 and v1.1.2 to all executors
 

--- a/terraform/executor/Dockerfile
+++ b/terraform/executor/Dockerfile
@@ -9,7 +9,7 @@ ARG AWSCLI_VERSION=1.19.16
 ARG HELM3_VERSION=3.5.3
 
 # internal providers
-ARG TF_OVO_VERSIONS="1.0.0"
+ARG TF_OVO_VERSIONS="1.0.0 1.1.0 1.9.9"
 ARG TF_AIVEN_KAFKA_USERS_VERSIONS="0.0.1 1.0.1 1.0.2 1.0.3 1.0.4 1.0.5 1.0.6 1.0.7 1.0.8 1.0.9 1.0.10 1.1.0 1.1.1 1.1.2"
 
 # Terraform environment variables
@@ -48,7 +48,7 @@ RUN mkdir -p $TF_PLUGIN_CACHE_DIR
 # kafka users ovo provider
 RUN mkdir -p /root/.terraform.d/plugins \
     && for TF_OVO_VERSION in $TF_OVO_VERSIONS; do \
-    curl -f -L https://ovo-kafka-user.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
+    curl -f -L https://kafka-users-prod-tf-provider.s3.eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
     && mkdir -p /root/.terraform.d/plugins/terraform.ovotech.org.uk/pe/ovo/${TF_OVO_VERSION}/linux_amd64 \
     && unzip ovo.zip -d /root/.terraform.d/plugins \
     && unzip ovo.zip -d /root/.terraform.d/plugins/terraform.ovotech.org.uk/pe/ovo/${TF_OVO_VERSION}/linux_amd64 \

--- a/terraform/executor/Dockerfile-0.11
+++ b/terraform/executor/Dockerfile-0.11
@@ -14,7 +14,7 @@ ARG TF_HELM_VERSIONS="0.6.0 0.5.1 0.5.0 0.4.0 0.3.2 0.3.1 0.3.0 0.2.0 0.1.0"
 ARG TF_ACME_VERSIONS="1.0.0 0.6.0 0.5.0 0.4.0 0.3.0"
 ARG TF_AIVEN_VERSIONS="1.0.19 1.0.20 1.1.0 1.1.1 1.1.2 1.1.3 1.1.4"
 ARG TF_OLD_AIVEN_VERSIONS="1.0.0 1.0.1 1.0.2 1.0.3 1.0.4 1.0.5 1.0.6 1.0.7 1.0.8 1.0.9 1.0.10 1.0.11 1.0.12 1.0.13 1.0.15 1.0.16 1.0.17 1.0.18"
-ARG TF_OVO_VERSIONS="1.0.0"
+ARG TF_OVO_VERSIONS="1.0.0 1.1.0 1.9.9"
 ARG TF_AIVEN_KAFKA_USERS_VERSIONS="0.0.1 1.0.1 1.0.2 1.0.3 1.0.4 1.0.5 1.0.6 1.0.7 1.0.8 1.0.9 1.0.10 1.1.0 1.1.1 1.1.2"
 
 # Terraform environment variables
@@ -90,7 +90,7 @@ RUN for TF_ACME_VERSION in $TF_ACME_VERSIONS; do \
 
 # ovo provider
 RUN for TF_OVO_VERSION in $TF_OVO_VERSIONS; do \
-      curl -f -L https://ovo-kafka-user.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
+      curl -f -L https://kafka-users-prod-tf-provider.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
       && unzip ovo.zip -d /root/.terraform.d/plugins \
       && rm ovo.zip; \
     done

--- a/terraform/executor/Dockerfile-0.12
+++ b/terraform/executor/Dockerfile-0.12
@@ -15,7 +15,7 @@ ARG TFSWITCH_VERSION=0.13.1275
 ARG NEW_TF_AIVEN_VERSIONS="2.0.1 2.0.5 2.0.6"
 ARG TF_AIVEN_VERSIONS="1.0.19 1.0.20 1.1.0 1.1.1 1.1.2 1.1.3 1.1.4 1.3.5"
 ARG TF_OLD_AIVEN_VERSIONS="1.0.0 1.0.1 1.0.2 1.0.3 1.0.4 1.0.5 1.0.6 1.0.7 1.0.8 1.0.9 1.0.10 1.0.11 1.0.12 1.0.13 1.0.15 1.0.16 1.0.17 1.0.18"
-ARG TF_OVO_VERSIONS="1.0.0"
+ARG TF_OVO_VERSIONS="1.0.0 1.1.0 1.9.9"
 ARG TF_AIVEN_KAFKA_USERS_VERSIONS="0.0.1 1.0.1 1.0.2 1.0.3 1.0.4 1.0.5 1.0.6 1.0.7 1.0.8 1.0.9 1.0.10 1.1.0 1.1.1 1.1.2"
 
 # Terraform environment variables
@@ -85,7 +85,7 @@ RUN curl -fsL "https://get.helm.sh/helm-v${HELM3_VERSION}-linux-amd64.tar.gz" | 
 # ovo provider
 RUN mkdir -p /root/.terraform.d/plugins \
  && for TF_OVO_VERSION in $TF_OVO_VERSIONS; do \
-      curl -f -L https://ovo-kafka-user.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
+      curl -f -L https://kafka-users-prod-tf-provider.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
       && unzip ovo.zip -d /root/.terraform.d/plugins \
       && rm ovo.zip; \
     done

--- a/terraform/executor/Dockerfile-0.12-slim
+++ b/terraform/executor/Dockerfile-0.12-slim
@@ -13,7 +13,7 @@ ARG HELM2_VERSION=2.16.10
 ARG HELM3_VERSION=3.3.1
 ARG TFSWITCH_VERSION=0.13.1275
 ARG TF_AIVEN_VERSIONS="2.0.6"
-ARG TF_OVO_VERSIONS="1.0.0"
+ARG TF_OVO_VERSIONS="1.0.0 1.1.0 1.9.9"
 ARG TF_AIVEN_KAFKA_USERS_VERSIONS="0.0.1 1.0.1 1.0.2 1.0.3 1.0.4 1.0.5 1.0.6 1.0.7 1.0.8 1.0.9 1.0.10 1.1.0 1.1.1 1.1.2"
 
 # Terraform environment variables
@@ -71,7 +71,7 @@ RUN curl -fsL "https://get.helm.sh/helm-v${HELM3_VERSION}-linux-amd64.tar.gz" | 
 # ovo provider
 RUN mkdir -p /root/.terraform.d/plugins \
  && for TF_OVO_VERSION in $TF_OVO_VERSIONS; do \
-      curl -f -L https://ovo-kafka-user.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
+      curl -f -L https://kafka-users-prod-tf-provider.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
       && unzip ovo.zip -d /root/.terraform.d/plugins \
       && rm ovo.zip; \
     done

--- a/terraform/executor/Dockerfile-0.13
+++ b/terraform/executor/Dockerfile-0.13
@@ -16,7 +16,7 @@ ARG TFSWITCH_VERSION=0.13.1275
 # Recommended not to use v1.3.5 but instead use TF builtin `required_providers`
 # to automatically install the correct v2.x Aiven provider
 ARG TF_AIVEN_VERSIONS="1.3.5"
-ARG TF_OVO_VERSIONS="1.0.0"
+ARG TF_OVO_VERSIONS="1.0.0 1.1.0 1.9.9"
 ARG TF_AIVEN_KAFKA_USERS_VERSIONS="0.0.1 1.0.1 1.0.2 1.0.3 1.0.4 1.0.5 1.0.6 1.0.7 1.0.8 1.0.9 1.0.10 1.1.0 1.1.1 1.1.2"
 
 # Terraform environment variables
@@ -74,7 +74,7 @@ RUN curl -fsL "https://get.helm.sh/helm-v${HELM3_VERSION}-linux-amd64.tar.gz" | 
 # kafka users ovo provider
 RUN mkdir -p /root/.terraform.d/plugins \
  && for TF_OVO_VERSION in $TF_OVO_VERSIONS; do \
-      curl -f -L https://ovo-kafka-user.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
+      curl -f -L https://kafka-users-prod-tf-provider.s3-eu-west-1.amazonaws.com/terraform-provider-ovo/${TF_OVO_VERSION}/terraform-provider-ovo_${TF_OVO_VERSION}_linux_amd64.zip -o ovo.zip \
       && mkdir -p /root/.terraform.d/plugins/terraform.ovotech.org.uk/pe/ovo/${TF_OVO_VERSION}/linux_amd64 \
       && unzip ovo.zip -d /root/.terraform.d/plugins/terraform.ovotech.org.uk/pe/ovo/${TF_OVO_VERSION}/linux_amd64 \
       && rm ovo.zip; \

--- a/terraform/orb_version.txt
+++ b/terraform/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform@1.11.20
+ovotech/terraform@1.11.21


### PR DESCRIPTION
Including the new end-of-life provider version for the legacy v1 user provisioner. See [kafka-users#19](https://github.com/ovotech/kafka-users/pull/19) for more details