### PR TITLE
Dropped debug output that's appearing in Terraform plan text

### DIFF
--- a/terraform-v2/CHANGELOG.md
+++ b/terraform-v2/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
 not listed
 
+## ovotech/terraform-v2@2.5.8
+- Fixed bug causing the check that PR plan hasn't changed when applying to constantly fail
+
 ## ovotech/terraform-v2@2.5.7
 - Added Terraform Aiven Kafka users provider version v2.1.1 to all executors
 

--- a/terraform-v2/github.py
+++ b/terraform-v2/github.py
@@ -184,10 +184,8 @@ if __name__ == '__main__':
     {sys.argv[0]} status <status.txt
     {sys.argv[0]} get >plan.txt''')
 
-    print("aaa")
     comment = TerraformComment(find_pr())
 
-    print("---aaa")
     if sys.argv[1] == 'plan':
         comment.plan = sys.stdin.read().strip()
     elif sys.argv[1] == 'status':

--- a/terraform-v2/orb_version.txt
+++ b/terraform-v2/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform-v2@2.5.7
+ovotech/terraform-v2@2.5.8


### PR DESCRIPTION
This causes the check that a PR plan hasn't changed when applying to constantly fail.

Mistakenly added in 97dce86 and confirmed with author.