### PR TITLE
Prevent disclosure of registry credentials in logs in the Terraform V2 orb

### DIFF
--- a/terraform-v2/CHANGELOG.md
+++ b/terraform-v2/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
 not listed
 
+## ovotech/terraform-v2@2.5.9
+- Disable bash xtrace when handling registry tokens to avoid displaying them in logs
+
 ## ovotech/terraform-v2@2.5.8
 - Fixed bug causing the check that PR plan hasn't changed when applying to constantly fail
 

--- a/terraform-v2/orb_version.txt
+++ b/terraform-v2/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform-v2@2.5.8
+ovotech/terraform-v2@2.5.9

--- a/terraform-v2/setup.sh
+++ b/terraform-v2/setup.sh
@@ -21,9 +21,11 @@ if [ $(echo $tf_version | cut -d '.' -f 1) -lt 1 ] && [ $(echo $tf_version | cut
     exit 1
 fi
 
+set +x
 if [ -n "$TF_REGISTRY_TOKEN" ]; then
     echo "credentials \"$TF_REGISTRY_HOST\" { token = \"$TF_REGISTRY_TOKEN\" }" >>$HOME/.terraformrc
 fi
+set -x
 
 # Set TF environment variables
 # These are already set in the dockerfile, but set again just in case the orb is used with a different executor

--- a/terraform-v2/test.py
+++ b/terraform-v2/test.py
@@ -22,9 +22,11 @@ if [ $(echo $tf_version | cut -d '.' -f 1) -lt 1 ] && [ $(echo $tf_version | cut
     exit 1
 fi
 
+set +x
 if [ -n "$TF_REGISTRY_TOKEN" ]; then
     echo "credentials \"$TF_REGISTRY_HOST\" { token = \"$TF_REGISTRY_TOKEN\" }" >>$HOME/.terraformrc
 fi
+set -x
 
 # Set TF environment variables
 # These are already set in the dockerfile, but set again just in case the orb is used with a different executor


### PR DESCRIPTION
This PR disables xtrace when testing for presence of and handling the environment variable `$TF_REGISTRY_TOKEN`, which is a sensitive value.