### PR TITLE
Add option to exclude pr comments when no terraform changes are present

### DIFF
--- a/terraform-v2/CHANGELOG.md
+++ b/terraform-v2/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to the orb will be documented in this file.
 Orbs are immutable, some orb versions with no significant changes are
 not listed
 
+## ovotech/terraform-v2@2.5.10
+- Add paramter `add_no_changes_comment` to exclude PR comments where there are no changes
+
 ## ovotech/terraform-v2@2.5.9
 - Disable bash xtrace when handling registry tokens to avoid displaying them in logs
 

--- a/terraform-v2/orb.yml
+++ b/terraform-v2/orb.yml
@@ -68,6 +68,11 @@ aliases:
         type: "boolean"
         description: "Add the plan to a GitHub PR"
         default: true
+      add_no_changes_comment: &add_no_changes_comment
+        add_no_changes_comment:
+          type: "boolean"
+          description: "Add the plan to a GitHub PR even if there are no changes"
+          default: true
     reuse_plan: &reuse_plan
       reuse_plan:
         type: "boolean"
@@ -135,6 +140,7 @@ commands:
       <<: *parallelism
       <<: *label
       <<: *add_github_comment
+      <<: *add_no_changes_comment
       <<: *target
       <<: *trim_plan
     steps:

--- a/terraform-v2/orb.yml
+++ b/terraform-v2/orb.yml
@@ -68,11 +68,11 @@ aliases:
         type: "boolean"
         description: "Add the plan to a GitHub PR"
         default: true
-      add_no_changes_comment: &add_no_changes_comment
-        add_no_changes_comment:
-          type: "boolean"
-          description: "Add the plan to a GitHub PR even if there are no changes"
-          default: true
+    add_no_changes_comment: &add_no_changes_comment
+      add_no_changes_comment:
+        type: "boolean"
+        description: "Add the plan to a GitHub PR even if there are no changes"
+        default: true
     reuse_plan: &reuse_plan
       reuse_plan:
         type: "boolean"

--- a/terraform-v2/orb_version.txt
+++ b/terraform-v2/orb_version.txt
@@ -1,1 +1,1 @@
-ovotech/terraform-v2@2.5.9
+ovotech/terraform-v2@2.5.10

--- a/terraform-v2/plan.sh
+++ b/terraform-v2/plan.sh
@@ -28,7 +28,7 @@ else
           | tee /dev/fd/3 \
           | $COMPACT_PLAN \
               >plan.txt
-  
+
   readonly TF_EXIT=${PIPESTATUS[0]}
 fi
 
@@ -43,7 +43,15 @@ if [[ -n "$GITHUB_TOKEN" && "<< parameters.add_github_comment >>" == "true" ]]; 
     export CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"
     export label="<< parameters.label >>"
 
-    if ! python3 /tmp/github.py plan <plan.txt; then
-        echo "Error adding comment to PR"
+    if terraform show -no-color plan.out | grep 'No changes' >/dev/null 2>&1; then
+      if [[ "<< parameters.add_no_changes_comment >>" == "true" ]]; then
+        if ! python3 /tmp/github.py plan <plan.txt; then
+            echo "Error adding comment to PR"
+        fi
+      fi
+    else
+      if ! python3 /tmp/github.py plan <plan.txt; then
+          echo "Error adding comment to PR"
+      fi
     fi
 fi

--- a/terraform-v2/plan.sh
+++ b/terraform-v2/plan.sh
@@ -43,7 +43,7 @@ if [[ -n "$GITHUB_TOKEN" && "<< parameters.add_github_comment >>" == "true" ]]; 
     export CIRCLE_PR_NUMBER="${CIRCLE_PR_NUMBER:-${CIRCLE_PULL_REQUEST##*/}}"
     export label="<< parameters.label >>"
 
-    if terraform show -no-color plan.out | grep 'No changes' >/dev/null 2>&1; then
+    if  grep 'No changes' plan.txt >/dev/null 2>&1; then
       if [[ "<< parameters.add_no_changes_comment >>" == "true" ]]; then
         if ! python3 /tmp/github.py plan <plan.txt; then
             echo "Error adding comment to PR"


### PR DESCRIPTION
We're looking for a way to only have the TF orb make pr comments when changes occur and skip this comment if there's nothing happening in the plans. I didn't update any tests here since it looks like a lot of these options are just hard coded