### PR TITLE
update docker version used

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -161,7 +161,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.13
+          version: docker23
       - run:
           name: docker build << parameters.path >>
           # language=bash


### PR DESCRIPTION
linked to: https://kaluza.atlassian.net/jira/software/c/projects/QE2/boards/497?selectedIssue=QE2-1003 

Updating the version used as given version is affected by https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176
